### PR TITLE
Fix raster file-list reading and remove ``preserve_units=True`` until astropy fix it

### DIFF
--- a/changelog/117.bugfix.1.rst
+++ b/changelog/117.bugfix.1.rst
@@ -1,0 +1,1 @@
+Removed ``preserve_units=True`` WCS construction paths due to upstream bug in astropy.

--- a/changelog/117.bugfix.1.rst
+++ b/changelog/117.bugfix.1.rst
@@ -1,1 +1,1 @@
-Removed ``preserve_units=True`` WCS construction paths due to upstream bug in astropy.
+Removed ``preserve_units=True`` WCS construction paths due to an upstream bug in Astropy.

--- a/changelog/117.bugfix.rst
+++ b/changelog/117.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed raster file-list reading so plain spectrograph FITS lists load the full observation sequence.

--- a/irispy/io/spectrograph.py
+++ b/irispy/io/spectrograph.py
@@ -155,7 +155,7 @@ def read_spectrograph_lvl2(
                     header["PC3_2"] = ang3
                     header["PC3_3"] = ang4
                 try:
-                    wcs = WCS(header, preserve_units=True)
+                    wcs = WCS(header)
                 except Exception as e:  # NOQA: BLE001
                     msg = (
                         f"WCS failed to load while reading one step of the raster due to {e}"
@@ -182,7 +182,7 @@ def read_spectrograph_lvl2(
                     header["PC3_2"] = -header["PC3_2"]
                     header["CDELT3"] = -header["CDELT3"]
                     header["CRPIX3"] = header["NAXIS3"] - header["CRPIX3"] + 1
-                    wcs = WCS(header, preserve_units=True)
+                    wcs = WCS(header)
                 else:
                     data = hdulist[window_fits_indices[i]].data
                 _set_wcs_aux_obs_coord(wcs, observer)

--- a/irispy/io/tests/test_utils.py
+++ b/irispy/io/tests/test_utils.py
@@ -37,6 +37,11 @@ def test_read_files_raster(sns_sg_file):
     assert read_files([sns_sg_file])
 
 
+def test_read_files_raster_file_list(raster_sg_files):
+    returns = read_files(raster_sg_files)
+    assert len(returns["Si IV 1403"]) == len(raster_sg_files)
+
+
 def test_read_files_sji(sns_sji_1330_file, sns_sji_1400_file, sns_sji_2796_file, sns_sji_2832_file):
     # Simple test to ensure it does not error
     assert read_files(sns_sji_1330_file)

--- a/irispy/io/tests/test_utils.py
+++ b/irispy/io/tests/test_utils.py
@@ -61,7 +61,7 @@ def test_get_spec_group_key_falls_back_when_metadata_is_missing(monkeypatch, tmp
 
     monkeypatch.setattr("irispy.io.utils.fits.getheader", lambda _: {"OBSID": None, "STARTOBS": ""})
 
-    assert _get_spec_group_key(filename) == (filename,)
+    assert _get_spec_group_key(filename) == (filename, None)
 
 
 def test_get_spec_group_key_falls_back_when_header_read_fails(monkeypatch, tmp_path):
@@ -74,7 +74,7 @@ def test_get_spec_group_key_falls_back_when_header_read_fails(monkeypatch, tmp_p
 
     monkeypatch.setattr("irispy.io.utils.fits.getheader", raise_oserror)
 
-    assert _get_spec_group_key(filename) == (filename,)
+    assert _get_spec_group_key(filename) == (filename, None)
 
 
 def test_read_files_raster_file_list_multiple_observations_use_unique_keys(raster_sg_file, sns_sg_file):

--- a/irispy/io/tests/test_utils.py
+++ b/irispy/io/tests/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from irispy.io.utils import fits_info, read_files
+from irispy.io.utils import _get_spec_group_key, fits_info, read_files
 
 
 def test_fits_info(capsys, sns_sg_file, sns_sji_1330_file, sns_sji_1400_file, sns_sji_2796_file, sns_sji_2832_file):
@@ -39,7 +39,40 @@ def test_read_files_raster(sns_sg_file):
 
 def test_read_files_raster_file_list(raster_sg_files):
     returns = read_files(raster_sg_files)
+    assert set(returns.keys()) == {
+        "C II 1336",
+        "1343",
+        "Fe XII 1349",
+        "O I 1356",
+        "Si IV 1403",
+        "2832",
+        "2826",
+        "2814",
+        "Mg II k 2796",
+    }
     assert len(returns["Si IV 1403"]) == len(raster_sg_files)
+
+
+def test_get_spec_group_key_falls_back_when_metadata_is_missing(monkeypatch, tmp_path):
+    filename = tmp_path / "missing-grouping-metadata.fits"
+    filename.touch()
+
+    monkeypatch.setattr("irispy.io.utils.fits.getheader", lambda _: {"OBSID": None, "STARTOBS": ""})
+
+    assert _get_spec_group_key(filename) == (filename,)
+
+
+def test_get_spec_group_key_falls_back_when_header_read_fails(monkeypatch, tmp_path):
+    filename = tmp_path / "unreadable-header.fits"
+    filename.touch()
+
+    def raise_oserror(_):
+        msg = "cannot read header"
+        raise OSError(msg)
+
+    monkeypatch.setattr("irispy.io.utils.fits.getheader", raise_oserror)
+
+    assert _get_spec_group_key(filename) == (filename,)
 
 
 def test_read_files_sji(sns_sji_1330_file, sns_sji_1400_file, sns_sji_2796_file, sns_sji_2832_file):

--- a/irispy/io/tests/test_utils.py
+++ b/irispy/io/tests/test_utils.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from astropy.io import fits
+
 from irispy.io.utils import _get_spec_group_key, fits_info, read_files
 
 
@@ -73,6 +75,36 @@ def test_get_spec_group_key_falls_back_when_header_read_fails(monkeypatch, tmp_p
     monkeypatch.setattr("irispy.io.utils.fits.getheader", raise_oserror)
 
     assert _get_spec_group_key(filename) == (filename,)
+
+
+def test_read_files_raster_file_list_multiple_observations_use_unique_keys(raster_sg_file, sns_sg_file):
+    filenames = sorted([raster_sg_file, sns_sg_file])
+    first_describe = fits.getheader(filenames[0]).get("TDESC1")
+    second_obsid = fits.getheader(filenames[1]).get("OBSID")
+
+    returns = read_files(filenames)
+
+    assert len(returns) == 2
+    assert set(returns.keys()) == {first_describe, f"{first_describe} ({second_obsid})"}
+
+
+def test_read_files_grouped_spectrograph_honors_allow_errors(
+    monkeypatch,
+    raster_sg_files,
+    sns_sji_1330_file,
+    sns_sji_1400_file,
+):
+    expected = read_files([sns_sji_1330_file, sns_sji_1400_file])
+
+    def raise_value_error(*_args, **_kwargs):
+        msg = "grouped spectrograph load failed"
+        raise ValueError(msg)
+
+    monkeypatch.setattr("irispy.io.utils.read_spectrograph_lvl2", raise_value_error)
+
+    returns = read_files([sns_sji_1330_file, sns_sji_1400_file, *raster_sg_files], allow_errors=True)
+
+    assert list(returns.keys()) == list(expected.keys())
 
 
 def test_read_files_sji(sns_sji_1330_file, sns_sji_1400_file, sns_sji_2796_file, sns_sji_2832_file):

--- a/irispy/io/utils.py
+++ b/irispy/io/utils.py
@@ -30,8 +30,9 @@ def _get_simple_metadata(file):
     """
     if not file.name.endswith(".fits") and not file.name.endswith(".fits.gz"):
         return "", ""
-    instrume = fits.getval(file, "INSTRUME")
-    describe = fits.getval(file, "TDESC1")
+    header = fits.getheader(file)
+    instrume = header.get("INSTRUME", "")
+    describe = header.get("TDESC1", "")
     return instrume, describe
 
 
@@ -83,6 +84,20 @@ def _get_spec_group_key(file):
     if obsid is None or not startobs:
         return (file,)
     return obsid, startobs
+
+
+def _get_spec_return_key(file_group, describe, returns):
+    key = f"{describe}"
+    if key not in returns:
+        return key
+    group_key = _get_spec_group_key(file_group[0])
+    if len(group_key) == 1:
+        return f"{describe} ({Path(group_key[0]).stem})"
+    obsid, startobs = group_key
+    key = f"{describe} ({obsid})"
+    if key not in returns:
+        return key
+    return f"{describe} ({obsid}, {startobs})"
 
 
 def fits_info(filename: str) -> None:
@@ -148,10 +163,13 @@ def read_files(filenames, *, spectral_windows=None, uncertainty=False, memmap=Fa
         If `True` (not the default), will compute the uncertainty for the data (slower and
         uses more memory). If ``memmap=True``, the uncertainty is never computed.
     memmap : `bool`, optional
-        If `True` (not the default), data is loaded lazily using Dask — arrays
-        are not read from disk until accessed. This keeps memory usage low when
-        working with many files at once. If ``memmap=True``, the uncertainty is
-        never computed.
+        If `True` (not the default), FITS data are opened using Astropy/NumPy
+        memory mapping rather than being fully read into memory at once. This
+        can keep memory usage low when working with many files, since array
+        data are accessed from disk on demand. In this mode FITS image scaling
+        is disabled, so the returned data are unscaled/raw FITS values rather
+        than automatically scaled physical values. If ``memmap=True``, the
+        uncertainty is never computed.
     allow_errors : `bool`, optional
         Will continue loading the files if one fails to load.
         Defaults to `False`.
@@ -197,8 +215,15 @@ def read_files(filenames, *, spectral_windows=None, uncertainty=False, memmap=Fa
                 continue
             raise
     for file_group in spec_groups.values():
-        instrume, describe = _get_simple_metadata(file_group[0])
-        returns[f"{describe}"] = read_spectrograph_lvl2(
-            file_group, spectral_windows=spectral_windows, memmap=memmap, uncertainty=uncertainty, **kwargs
-        )
+        try:
+            instrume, describe = _get_simple_metadata(file_group[0])
+            key = _get_spec_return_key(file_group, describe, returns)
+            returns[key] = read_spectrograph_lvl2(
+                file_group, spectral_windows=spectral_windows, memmap=memmap, uncertainty=uncertainty, **kwargs
+            )
+        except Exception as e:
+            if allow_errors:
+                log.warning(f"File group {file_group} failed to load with {e}")
+                continue
+            raise
     return NDCollection(returns.items()) if len(returns) > 1 else next(iter(returns.values()))

--- a/irispy/io/utils.py
+++ b/irispy/io/utils.py
@@ -58,6 +58,25 @@ def _extract_tarfile(filenames):
     return expanded_files
 
 
+def _get_spec_group_key(file):
+    """
+    Group spectrograph FITS files that belong to the same observation.
+
+    Parameters
+    ----------
+    file : `pathlib.Path`
+        The FITS file to inspect.
+
+    Returns
+    -------
+    `tuple`
+        Key built from stable observation-identifying header metadata.
+    """
+    obsid = fits.getval(file, "OBSID")
+    startobs = fits.getval(file, "STARTOBS")
+    return obsid, startobs
+
+
 def fits_info(filename: str) -> None:
     """
     Prints information about the extension of a raster or SJI level 2 data file.
@@ -121,10 +140,10 @@ def read_files(filenames, *, spectral_windows=None, uncertainty=False, memmap=Fa
         If `True` (not the default), will compute the uncertainty for the data (slower and
         uses more memory). If ``memmap=True``, the uncertainty is never computed.
     memmap : `bool`, optional
-        If `True` (not the default), will not load arrays into memory, and will only read from
-        the file into memory when needed. This option is faster and uses a
-        lot less memory. However, because FITS scaling is not done on-the-fly,
-        the data units will be unscaled, not the usual data numbers (DN).
+        If `True` (not the default), data is loaded lazily using Dask — arrays
+        are not read from disk until accessed. This keeps memory usage low when
+        working with many files at once. If ``memmap=True``, the uncertainty is
+        never computed.
     allow_errors : `bool`, optional
         Will continue loading the files if one fails to load.
         Defaults to `False`.
@@ -141,6 +160,7 @@ def read_files(filenames, *, spectral_windows=None, uncertainty=False, memmap=Fa
     filenames = sorted(filenames)
     filenames = [Path(f) for f in filenames]
     returns = {}
+    spec_groups = {}
     for filename in filenames:
         sdo_tarfile = bool(filename.name.endswith("SDO.tar.gz"))
         raster_tarfile = bool(filename.name.endswith("_raster.tar.gz"))
@@ -152,12 +172,15 @@ def read_files(filenames, *, spectral_windows=None, uncertainty=False, memmap=Fa
                 for f in file:
                     instrume, describe = _get_simple_metadata(f)
                     returns[f"{describe}"] = read_sji_lvl2(f, memmap=memmap, uncertainty=uncertainty, **kwargs)
-            elif raster_tarfile or instrume == "SPEC":
+            elif raster_tarfile:
                 file = _extract_tarfile([filename]) if raster_tarfile else [filename]
                 instrume, describe = _get_simple_metadata(file[0])
                 returns[f"{describe}"] = read_spectrograph_lvl2(
                     file, spectral_windows=spectral_windows, memmap=memmap, uncertainty=uncertainty, **kwargs
                 )
+            elif instrume == "SPEC":
+                group_key = _get_spec_group_key(filename)
+                spec_groups.setdefault(group_key, []).append(filename)
             else:
                 log.warning(f"INSTRUME: {instrume} was not recognized and not loaded")
         except Exception as e:
@@ -165,4 +188,9 @@ def read_files(filenames, *, spectral_windows=None, uncertainty=False, memmap=Fa
                 log.warning(f"File {filename} failed to load with {e}")
                 continue
             raise
+    for file_group in spec_groups.values():
+        instrume, describe = _get_simple_metadata(file_group[0])
+        returns[f"{describe}"] = read_spectrograph_lvl2(
+            file_group, spectral_windows=spectral_windows, memmap=memmap, uncertainty=uncertainty, **kwargs
+        )
     return NDCollection(returns.items()) if len(returns) > 1 else next(iter(returns.values()))

--- a/irispy/io/utils.py
+++ b/irispy/io/utils.py
@@ -78,11 +78,11 @@ def _get_spec_group_key(file):
     try:
         header = fits.getheader(file)
     except OSError:
-        return (file,)
+        return file, None
     obsid = header.get("OBSID")
     startobs = header.get("STARTOBS")
     if obsid is None or not startobs:
-        return (file,)
+        return file, None
     return obsid, startobs
 
 
@@ -91,9 +91,9 @@ def _get_spec_return_key(file_group, describe, returns):
     if key not in returns:
         return key
     group_key = _get_spec_group_key(file_group[0])
-    if len(group_key) == 1:
-        return f"{describe} ({Path(group_key[0]).stem})"
     obsid, startobs = group_key
+    if startobs is None:
+        return f"{describe} ({Path(obsid).stem})"
     key = f"{describe} ({obsid})"
     if key not in returns:
         return key

--- a/irispy/io/utils.py
+++ b/irispy/io/utils.py
@@ -71,9 +71,17 @@ def _get_spec_group_key(file):
     -------
     `tuple`
         Key built from stable observation-identifying header metadata.
+        Falls back to a per-file key if the header cannot be read or if
+        the observation-grouping metadata is missing.
     """
-    obsid = fits.getval(file, "OBSID")
-    startobs = fits.getval(file, "STARTOBS")
+    try:
+        header = fits.getheader(file)
+    except OSError:
+        return (file,)
+    obsid = header.get("OBSID")
+    startobs = header.get("STARTOBS")
+    if obsid is None or not startobs:
+        return (file,)
     return obsid, startobs
 
 
@@ -162,11 +170,11 @@ def read_files(filenames, *, spectral_windows=None, uncertainty=False, memmap=Fa
     returns = {}
     spec_groups = {}
     for filename in filenames:
-        sdo_tarfile = bool(filename.name.endswith("SDO.tar.gz"))
-        raster_tarfile = bool(filename.name.endswith("_raster.tar.gz"))
-        instrume, describe = _get_simple_metadata(filename)
-        log.debug(f"Processing file: {filename} with instrume: {instrume}")
         try:
+            sdo_tarfile = bool(filename.name.endswith("SDO.tar.gz"))
+            raster_tarfile = bool(filename.name.endswith("_raster.tar.gz"))
+            instrume, describe = _get_simple_metadata(filename)
+            log.debug(f"Processing file: {filename} with instrume: {instrume}")
             if sdo_tarfile or instrume in ["IRIS", "SJI"] or instrume.startswith("AIA"):
                 file = _extract_tarfile([filename]) if sdo_tarfile else [filename]
                 for f in file:

--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -289,8 +289,8 @@ class SJICube(SpectrogramCube):
         if self._basic_wcs is None:
             return None
         if isinstance(self._basic_wcs, MetaDict):
-            return WCS(self._basic_wcs, preserve_units=True)
-        return [WCS(wcs_header, preserve_units=True) for wcs_header in self._basic_wcs]
+            return WCS(self._basic_wcs)
+        return [WCS(wcs_header) for wcs_header in self._basic_wcs]
 
     def to_maps(self, index: int | list[int] | None = None):
         """

--- a/irispy/tests/test_sji_fake_data.py
+++ b/irispy/tests/test_sji_fake_data.py
@@ -44,7 +44,7 @@ def cube():
         "CRVAL3": 0,
         "NAXIS3": 2,
     }
-    wcs = WCS(header=header, naxis=3, preserve_units=True)
+    wcs = WCS(header=header, naxis=3)
     cube = SJICube(
         data,
         wcs,
@@ -77,7 +77,7 @@ def cube_2d():
         "NAXIS2": 3,
     }
     exposure_times = 2 * np.ones((2), float) * u.s
-    wcs_2d = WCS(header=header_2d, naxis=2, preserve_units=True)
+    wcs_2d = WCS(header=header_2d, naxis=2)
     cube_2d = SJICube(
         data_2d,
         wcs_2d,
@@ -102,7 +102,7 @@ def cube_1d():
         "NAXIS1": 2,
     }
     exposure_times = 2 * np.ones((2), float) * u.s
-    wcs_1d = WCS(header=header_1d, naxis=1, preserve_units=True)
+    wcs_1d = WCS(header=header_1d, naxis=1)
     data_1d = np.array([1, 2])
     cube_1d = SJICube(
         data_1d,
@@ -145,7 +145,7 @@ def dust_cube():
         "CRVAL3": 0,
         "NAXIS3": 2,
     }
-    wcs = WCS(header=header, naxis=3, preserve_units=True)
+    wcs = WCS(header=header, naxis=3)
     unit = utils.constants.DN_UNIT["SJI"]
     mask_dust = data_dust == BAD_PIXEL_VALUE_SCALED
 

--- a/irispy/utils/wobble.py
+++ b/irispy/utils/wobble.py
@@ -86,7 +86,7 @@ def generate_wobble_movie(
         with fits.open(a_file) as hdulist:
             data = hdulist[0].data
             header = hdulist[0].header
-            wcs = WCS(header, preserve_units=True)
+            wcs = WCS(header)
             numframes = header["NAXIS3"]
             date = header["STARTOBS"].split(".")[0]
             # Calculate index to downsample in time to accentuate the wobble


### PR DESCRIPTION
## Summary by Sourcery

Group spectrograph raster FITS files by observation when reading file lists and align WCS usage with current astropy behavior.

Bug Fixes:
- Fix reading of raster spectrograph data when multiple related FITS files are provided as a file list instead of a tarball.

Enhancements:
- Clarify read_files memmap documentation to describe lazy loading with Dask.
- Standardize WCS construction across spectrograph, SJI, and wobble utilities by removing the preserve_units parameter pending an upstream astropy fix.

Documentation:
- Add changelog entries documenting the raster file-list fix and WCS preserve_units behavior change.

Tests:
- Add a regression test to ensure raster spectrograph file lists are read correctly into collections.