### PR TITLE
Add raster gWCS support

### DIFF
--- a/irispy/io/spectrograph.py
+++ b/irispy/io/spectrograph.py
@@ -98,7 +98,7 @@ def _pc_matrix(lam, angle_1, angle_2):
     return angle_1, -1 * lam * angle_2, 1 / lam * angle_2, angle_1
 
 
-def _create_basic_raster_wcs(header, aux_data, spectral_band, observer, *, flip):
+def _prepare_raster_wcs_header(header, aux_data, spectral_band, *, flip):
     header = copy(header)
     if header.get("CUNIT1", "").lower() == "angstrom":
         header["CUNIT1"] = "nm"
@@ -123,6 +123,10 @@ def _create_basic_raster_wcs(header, aux_data, spectral_band, observer, *, flip)
         header["PC3_2"] = -header["PC3_2"]
         header["CDELT3"] = -header["CDELT3"]
         header["CRPIX3"] = header["NAXIS3"] - header["CRPIX3"] + 1
+    return header
+
+
+def _create_basic_raster_wcs(header, observer):
     wcs = WCS(header)
     _set_wcs_aux_obs_coord(wcs, observer)
     return wcs
@@ -155,25 +159,34 @@ def _create_raster_gwcs(window_header, pc_all, crval_all, dt_all, t_ref, observe
     from dkist.wcs.models import AsymmetricMapping, CoupledCompoundModel, VaryingCelestialTransform  # NOQA: PLC0415
     from sunpy.time import parse_time  # NOQA: PLC0415
 
-    cdelt1 = window_header["CDELT1"]
-    crval1 = window_header["CRVAL1"]
+    if window_header.get("CUNIT1", "").lower() == "angstrom":
+        cdelt1 = window_header["CDELT1"] * 0.1
+        crval1 = window_header["CRVAL1"] * 0.1
+    else:
+        cdelt1 = window_header["CDELT1"]
+        crval1 = window_header["CRVAL1"]
     crpix1 = window_header.get("CRPIX1", 1.0)
-    # Use nm to avoid the VOUnit 'Angstrom' deprecation warning emitted by
-    # gwcs when it serialises output-frame units via world_axis_units().
     spectral = m.Linear1D(
-        slope=cdelt1 * 0.1 * u.nm / u.pix,
-        intercept=(crval1 - cdelt1 * (crpix1 - 1)) * 0.1 * u.nm,
+        slope=cdelt1 * u.nm / u.pix,
+        intercept=(crval1 - cdelt1 * (crpix1 - 1)) * u.nm,
         name="Wavelength",
     )
 
     crpix_table = np.array([window_header["CRPIX2"], window_header["CRPIX3"]]) * u.pix
     cdelt = np.array([window_header["CDELT2"], window_header["CDELT3"]]) * (u.arcsec / u.pix)
-    celestial = VaryingCelestialTransform(
+    celestial_raw = VaryingCelestialTransform(
         cdelt=cdelt,
         pc_table=pc_all,
         crval_table=crval_all,
         crpix_table=crpix_table,
     )
+    if np.isclose(window_header["CDELT3"], 1e-10):
+        celestial = celestial_raw
+    else:
+        celestial = celestial_raw | m.Mapping((1, 0), name="SwapHelioprojectiveAxes")
+        celestial.inverse = m.Mapping((1, 0, 2), n_inputs=3, name="SwapHelioprojectiveAxesInverseInputs") | (
+            celestial_raw.inverse
+        )
 
     temporal = m.Tabular1D(
         np.arange(pc_all.shape[0]) * u.pix,
@@ -190,10 +203,12 @@ def _create_raster_gwcs(window_header, pc_all, crval_all, dt_all, t_ref, observe
         1, name="step"
     )
     non_spectral = slit_step_mapping | non_spectral_rhs
+    # The explicit scan-step axis is the authoritative inverse for the raster/time dimension.
+    # This keeps round-trips stable when sky coordinates repeat, e.g. sit-and-stare exposures.
     non_spectral.inverse = non_spectral_rhs.inverse | m.Mapping(
-        (0, 1),
+        (0, 3),
         n_inputs=4,
-        name="SelectSlitAndStep",
+        name="SelectSlitAndExplicitStep",
     )
     forward_transform = spectral & non_spectral
     forward_transform.inverse = spectral.inverse & non_spectral.inverse
@@ -346,8 +361,8 @@ def read_spectrograph_lvl2(
             aux = hdulist[-2]
             file_startobs = _header_time(file_primary_header, "STARTOBS", "DATE_OBS")
 
-            pc = aux.data[:, aux.header["PC2_2IX"] : aux.header["PC3_3IX"] + 1].reshape(-1, 2, 2) * u.pix
-            crval = aux.data[:, aux.header["XCENIX"] : aux.header["YCENIX"] + 1] * u.arcsec
+            pc_indices = [aux.header[key] for key in ("PC2_2IX", "PC2_3IX", "PC3_2IX", "PC3_3IX")]
+            pc = aux.data[:, pc_indices].reshape(-1, 2, 2) * u.pix
             times = file_startobs + TimeDelta(aux.data[:, aux.header["TIME"]] * u.s)
             exp_fuv = aux.data[:, aux.header["EXPTIMEF"]] * u.s
             exp_nuv = aux.data[:, aux.header["EXPTIMEN"]] * u.s
@@ -356,7 +371,6 @@ def read_spectrograph_lvl2(
 
             if v34 and not revert_v34:
                 pc = pc[::-1]
-                crval = crval[::-1]
                 times = times[::-1]
                 exp_fuv = exp_fuv[::-1]
                 exp_nuv = exp_nuv[::-1]
@@ -373,13 +387,26 @@ def read_spectrograph_lvl2(
                     window_name,
                     data_shape=(window_header["NAXIS3"], window_header["NAXIS2"], window_header["NAXIS1"]),
                 )
-                basic_wcs = _create_basic_raster_wcs(
+                prepared_wcs_header = _prepare_raster_wcs_header(
                     window_header,
                     aux.data,
                     meta.spectral_band,
-                    observer,
                     flip=flip,
                 )
+                if np.isclose(window_header["CDELT3"], 0):
+                    crval = np.repeat(
+                        [[prepared_wcs_header["CRVAL3"], prepared_wcs_header["CRVAL2"]]],
+                        len(times),
+                        axis=0,
+                    ) * u.arcsec
+                else:
+                    offset_index = 34 if meta.spectral_band == "FUV" else 45
+                    xcen = aux.data[:, aux.header["XCENIX"]] - aux.data[:, offset_index] * (SLIT_WIDTH.value / 2)
+                    ycen = aux.data[:, aux.header["YCENIX"]]
+                    crval = np.column_stack((ycen, xcen)) * u.arcsec
+                    if flip:
+                        crval = crval[::-1]
+                basic_wcs = _create_basic_raster_wcs(prepared_wcs_header, observer)
 
                 is_fuv = "FUV" in meta.detector
                 dn_unit = DN_UNIT["FUV"] if is_fuv else DN_UNIT["NUV"]
@@ -402,7 +429,7 @@ def read_spectrograph_lvl2(
                 cube = SpectrogramCube(
                     data,
                     wcs=_create_raster_gwcs(
-                        window_header,
+                        prepared_wcs_header,
                         pc,
                         crval,
                         dt,

--- a/irispy/io/spectrograph.py
+++ b/irispy/io/spectrograph.py
@@ -1,15 +1,19 @@
 from copy import copy
 from pathlib import Path
 
+import dask
+import dask.array as da
 import numpy as np
 
+import astropy.modeling.models as m
 import astropy.units as u
-from astropy.coordinates import SkyCoord
+import gwcs
+import gwcs.coordinate_frames as cf
+from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.io import fits
 from astropy.time import Time, TimeDelta
 from astropy.wcs import WCS
 
-from sunpy import log as logger
 from sunpy.coordinates.ephemeris import get_body_heliographic_stonyhurst
 from sunpy.coordinates.frames import HeliographicStonyhurst, Helioprojective
 from sunpy.coordinates.screens import SphericalScreen
@@ -23,8 +27,209 @@ from irispy.utils.constants import BAD_PIXEL_VALUE_SCALED, DN_UNIT, READOUT_NOIS
 __all__ = ["read_spectrograph_lvl2"]
 
 
+class _IRISRasterGWCS(gwcs.WCS):
+    def __init__(self, *args, basic_wcs=None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._basic_wcs = basic_wcs
+
+    @staticmethod
+    def _supports_legacy_basic_wcs_bridge(world_objects):
+        return (
+            len(world_objects) == 2
+            and isinstance(world_objects[0], SpectralCoord)
+            and isinstance(world_objects[1], SkyCoord)
+        )
+
+    @property
+    def celestial(self):
+        if self._basic_wcs is None:
+            msg = "This raster gWCS does not have an associated basic celestial WCS."
+            raise AttributeError(msg)
+        return self._basic_wcs.celestial
+
+    def world_to_pixel(self, *world_objects):
+        if self._basic_wcs is not None and self._supports_legacy_basic_wcs_bridge(world_objects):
+            return self._basic_wcs.world_to_pixel(*world_objects)
+        return super().world_to_pixel(*world_objects)
+
+    def world_to_array_index(self, *world_objects):
+        if self._basic_wcs is not None and self._supports_legacy_basic_wcs_bridge(world_objects):
+            return self._basic_wcs.world_to_array_index(*world_objects)
+        return super().world_to_array_index(*world_objects)
+
+
+def _load_raster_window(filename, ext_idx, flip_step_axis):
+    """
+    Load and return scaled data for one spectral window from one raster FITS file.
+
+    Used as a ``dask.delayed`` callable so that data is only read from disk
+    when the resulting dask array is actually computed. The explicit cast to
+    ``float32`` guarantees the dtype matches the ``da.from_delayed`` declaration.
+    """
+    data = fits.getdata(filename, ext=ext_idx).astype(np.float32)
+    if flip_step_axis:
+        return np.flip(data, axis=0).copy()
+    return data
+
+
+def _header_time(header, *keys):
+    for key in keys:
+        value = header.get(key)
+        if value:
+            return Time(value, format="isot", scale="utc")
+    msg = f"Header is missing all usable time keys: {keys}"
+    raise ValueError(msg)
+
+
+def _make_observer(primary_header):
+    base_time = _header_time(primary_header, "DATE_OBS", "STARTOBS")
+    location = get_body_heliographic_stonyhurst("Earth", base_time.isot)
+    observer = Helioprojective(
+        primary_header["XCEN"] * u.arcsec,
+        primary_header["YCEN"] * u.arcsec,
+        observer=location,
+        obstime=base_time,
+    )
+    with SphericalScreen(observer.observer):
+        return observer.transform_to(HeliographicStonyhurst(obstime=base_time))
+
+
 def _pc_matrix(lam, angle_1, angle_2):
     return angle_1, -1 * lam * angle_2, 1 / lam * angle_2, angle_1
+
+
+def _create_basic_raster_wcs(header, aux_data, spectral_band, observer, *, flip):
+    header = copy(header)
+    if header.get("CUNIT1", "").lower() == "angstrom":
+        header["CUNIT1"] = "nm"
+        header["CRVAL1"] *= 0.1
+        header["CDELT1"] *= 0.1
+    offset_index = 34 if spectral_band == "FUV" else 45
+    header["CRVAL3"] -= aux_data[:, offset_index].mean() * (SLIT_WIDTH.value / 2)
+    if header["CDELT3"] == 0:
+        header["CDELT3"] = 1e-10
+        ang1, ang2, ang3, ang4 = _pc_matrix(
+            header["CDELT3"] / header["CDELT2"],
+            aux_data[:, 20].mean(),
+            aux_data[:, 22].mean(),
+        )
+        header["PC2_2"] = ang1
+        header["PC2_3"] = ang2
+        header["PC3_2"] = ang3
+        header["PC3_3"] = ang4
+    if flip:
+        header["PC1_3"] = 0
+        header["PC2_3"] = -header["PC2_3"]
+        header["PC3_2"] = -header["PC3_2"]
+        header["CDELT3"] = -header["CDELT3"]
+        header["CRPIX3"] = header["NAXIS3"] - header["CRPIX3"] + 1
+    wcs = WCS(header)
+    _set_wcs_aux_obs_coord(wcs, observer)
+    return wcs
+
+
+def _create_raster_gwcs(window_header, pc_all, crval_all, dt_all, t_ref, observer, basic_wcs):
+    """
+    Build a gWCS for an IRIS raster or sit-and-stare spectrograph window.
+
+    Pixel axes: (0=dispersion, 1=slit, 2=step) in FITS order.
+    World axes: (wavelength, helioprojective lon, lat, time, step).
+
+    Parameters
+    ----------
+    window_header : FITS header
+        Header from the window HDU of the first raster file.
+    pc_all : `~astropy.units.Quantity`
+        Per-step PC matrix, shape ``(N_steps, 2, 2)``, in ``u.pix``.
+    crval_all : `~astropy.units.Quantity`
+        Per-step celestial reference values, shape ``(N_steps, 2)``, in ``u.arcsec``.
+    dt_all : `~astropy.units.Quantity`
+        Per-step time offsets from ``t_ref``, shape ``(N_steps,)``, in ``u.s``.
+    t_ref : `~astropy.time.Time`
+        Reference time for the temporal frame.
+
+    Returns
+    -------
+    `gwcs.WCS`
+    """
+    from dkist.wcs.models import AsymmetricMapping, CoupledCompoundModel, VaryingCelestialTransform  # NOQA: PLC0415
+    from sunpy.time import parse_time  # NOQA: PLC0415
+
+    cdelt1 = window_header["CDELT1"]
+    crval1 = window_header["CRVAL1"]
+    crpix1 = window_header.get("CRPIX1", 1.0)
+    # Use nm to avoid the VOUnit 'Angstrom' deprecation warning emitted by
+    # gwcs when it serialises output-frame units via world_axis_units().
+    spectral = m.Linear1D(
+        slope=cdelt1 * 0.1 * u.nm / u.pix,
+        intercept=(crval1 - cdelt1 * (crpix1 - 1)) * 0.1 * u.nm,
+        name="Wavelength",
+    )
+
+    crpix_table = np.array([window_header["CRPIX2"], window_header["CRPIX3"]]) * u.pix
+    cdelt = np.array([window_header["CDELT2"], window_header["CDELT3"]]) * (u.arcsec / u.pix)
+    celestial = VaryingCelestialTransform(
+        cdelt=cdelt,
+        pc_table=pc_all,
+        crval_table=crval_all,
+        crpix_table=crpix_table,
+    )
+
+    temporal = m.Tabular1D(
+        np.arange(pc_all.shape[0]) * u.pix,
+        lookup_table=dt_all,
+        fill_value=np.nan,
+        bounds_error=False,
+        method="linear",
+        name="Time",
+    )
+
+    # (slit_pix, step_pix) → (slit, step, step, step): feeds celestial+temporal+step passthrough
+    slit_step_mapping = AsymmetricMapping([0, 1, 1, 1], [0, 1], name="SlitStepMapping")
+    non_spectral_rhs = CoupledCompoundModel("&", left=celestial, right=temporal, shared_inputs=1) & m.Identity(
+        1, name="step"
+    )
+    non_spectral = slit_step_mapping | non_spectral_rhs
+    non_spectral.inverse = non_spectral_rhs.inverse | m.Mapping(
+        (0, 1),
+        n_inputs=4,
+        name="SelectSlitAndStep",
+    )
+    forward_transform = spectral & non_spectral
+    forward_transform.inverse = spectral.inverse & non_spectral.inverse
+
+    base_time = parse_time(t_ref)
+    spectral_frame = cf.SpectralFrame(axes_order=(0,), unit=u.nm, name="wavelength", axes_names=("wavelength",))
+    celestial_frame = cf.CelestialFrame(
+        axes_order=(1, 2),
+        unit=(u.arcsec, u.arcsec),
+        reference_frame=Helioprojective(observer=observer, obstime=observer.obstime),
+        axis_physical_types=["custom:pos.helioprojective.lon", "custom:pos.helioprojective.lat"],
+        axes_names=("helioprojective longitude", "helioprojective latitude"),
+    )
+    temporal_frame = cf.TemporalFrame(base_time, unit=(u.s,), axes_order=(3,), axes_names=("Time (UTC)",))
+    step_frame = cf.CoordinateFrame(
+        naxes=1,
+        axes_order=(4,),
+        axes_names=("scan_step",),
+        axes_type=("STEP",),
+        unit=(u.pix,),
+        name="step",
+    )
+    output_frame = cf.CompositeFrame([spectral_frame, celestial_frame, temporal_frame, step_frame])
+    pixel_frame = cf.CoordinateFrame(
+        naxes=3,
+        axes_order=(0, 1, 2),
+        axes_names=["dispersion axis", "spatial along slit", "scan/step number"],
+        axes_type=["PIXEL", "PIXEL", "PIXEL"],
+        unit=(u.pix, u.pix, u.pix),
+    )
+    return _IRISRasterGWCS(
+        forward_transform,
+        input_frame=pixel_frame,
+        output_frame=output_frame,
+        basic_wcs=basic_wcs,
+    )
 
 
 def read_spectrograph_lvl2(
@@ -52,152 +257,173 @@ def read_spectrograph_lvl2(
         If `True` (not the default), will compute the uncertainty for the data (slower and
         uses more memory). If ``memmap=True``, the uncertainty is never computed.
     memmap : `bool`, optional
-        If `True` (not the default), will not load arrays into memory, and will only read from
-        the file into memory when needed. This option is faster and uses a
-        lot less memory. However, because FITS scaling is not done on-the-fly,
-        the data units will be unscaled, not the usual data numbers (DN).
+        If `True` (not the default), data is loaded lazily using Dask — arrays
+        are not read from disk until you access them. This keeps memory usage low
+        when loading many raster files. BSCALE/BZERO scaling is applied on first
+        access. A lazy bad-pixel mask is built. Uncertainties are not computed in this mode.
     revert_v34 : `bool`, optional.
         Will undo the data and WCS flipping made to V34 observations.
         Defaults to `False`.
 
     Returns
     -------
-    `RasterCollection`
+        `RasterCollection`
     """
     if isinstance(filenames, (str, Path)):
         filenames = [filenames]
-    filenames = [str(f) for f in filenames]
-    # Collecting the window observations
-    with fits.open(filenames[0], memmap=memmap, do_not_scale_image_data=memmap) as hdulist:
-        # After a discussion with the IRIS team, it was decided that instead of the
-        # OBSID, we will use STEPS_AV less than -0.01 to identify V34 observations.
-        v34 = hdulist[0].header["STEPS_AV"] < -0.01
-        hdulist.verify("silentfix")
-        windows_in_obs = np.array(
-            [hdulist[0].header[f"TDESC{i}"] for i in range(1, hdulist[0].header["NWIN"] + 1)],
-        )
-        # If spectral_window is not set then get every window.
-        # Else take the appropriate windows
-        if not spectral_windows:
-            spectral_windows_req = windows_in_obs
-            window_fits_indices = range(1, len(hdulist) - 2)
-        else:
-            spectral_windows_req = [spectral_windows] if isinstance(spectral_windows, str) else spectral_windows
-            spectral_windows_req = np.asarray(spectral_windows_req, dtype="U")
-            window_is_in_obs = np.asarray([window in windows_in_obs for window in spectral_windows_req])
-            if not all(window_is_in_obs):
-                missing_windows = window_is_in_obs is False
-                msg = f"Spectral windows {spectral_windows[missing_windows]} not in file {filenames[0]}"
-                raise ValueError(msg)
-            window_fits_indices = np.nonzero(np.isin(windows_in_obs, spectral_windows))[0] + 1
-        data_dict = {window_name: [] for window_name in spectral_windows_req}
-        # No observer information in the header, so we just assume its at Earth.
-        base_time = Time(hdulist[0].header["DATE_OBS"])
-        location = get_body_heliographic_stonyhurst("Earth", (base_time).isot)
-        observer = Helioprojective(
-            hdulist[0].header["XCEN"] * u.arcsec,
-            hdulist[0].header["YCEN"] * u.arcsec,
-            observer=location,
-            obstime=base_time,
-        )
-        with SphericalScreen(observer.observer):
-            observer = observer.transform_to(HeliographicStonyhurst(obstime=base_time))
-    for filename in filenames:
-        with fits.open(filename, memmap=memmap, do_not_scale_image_data=memmap) as hdulist:
-            hdulist.verify("silentfix")
-            # Extract axis-aligned metadata.
-            times = Time(hdulist[0].header["STARTOBS"]) + TimeDelta(
-                hdulist[-2].data[:, hdulist[-2].header["TIME"]],
-                format="sec",
-            )
-            fov_center = SkyCoord(
-                Tx=hdulist[-2].data[:, hdulist[-2].header["XCENIX"]],
-                Ty=hdulist[-2].data[:, hdulist[-2].header["YCENIX"]],
-                unit=u.arcsec,
-                frame=Helioprojective,
-            )
-            obs_vrix = hdulist[-2].data[:, hdulist[-2].header["OBS_VRIX"]] * u.m / u.s
-            ophaseix = hdulist[-2].data[:, hdulist[-2].header["OPHASEIX"]]
-            exposure_times_fuv = hdulist[-2].data[:, hdulist[-2].header["EXPTIMEF"]] * u.s
-            exposure_times_nuv = hdulist[-2].data[:, hdulist[-2].header["EXPTIMEN"]] * u.s
-            for i, window_name in enumerate(spectral_windows_req):
-                meta = SGMeta(
-                    hdulist[0].header,
-                    window_name,
-                    data_shape=hdulist[window_fits_indices[i]].data.shape,
-                )
-                exposure_times = exposure_times_nuv
-                dn_unit = DN_UNIT["NUV"]
-                readout_noise = READOUT_NOISE["NUV"]
-                if "FUV" in meta.detector:
-                    exposure_times = exposure_times_fuv
-                    dn_unit = DN_UNIT["FUV"]
-                    readout_noise = READOUT_NOISE["FUV"]
-                meta.add("exposure time", exposure_times, None, 0)
-                meta.add("exposure FOV center", fov_center, None, 0)
-                meta.add("observer radial velocity", obs_vrix, None, 0)
-                meta.add("orbital phase", ophaseix, None, 0)
-                # Sit-and-stare have a CDELT of 0 which causes issues in WCS.
-                # In this case, set CDELT to a small number.
-                header = copy(hdulist[window_fits_indices[i]].header)
-                # Account for a slit offset (POFFYNUV (45) or POFFYFUV (34))
-                idx = 34 if meta.spectral_band == "FUV" else 45
-                header["CRVAL3"] -= hdulist[-2].data[:, idx].mean() * (SLIT_WIDTH.value / 2)
-                if header["CDELT3"] == 0:
-                    header["CDELT3"] = 1e-10
-                    ang1, ang2, ang3, ang4 = _pc_matrix(
-                        header["CDELT3"] / header["CDELT2"],
-                        hdulist[-2].data[:, 20].mean(),
-                        hdulist[-2].data[:, 22].mean(),
-                    )
-                    header["PC2_2"] = ang1
-                    header["PC2_3"] = ang2
-                    header["PC3_2"] = ang3
-                    header["PC3_3"] = ang4
-                try:
-                    wcs = WCS(header)
-                except Exception as e:  # NOQA: BLE001
-                    msg = (
-                        f"WCS failed to load while reading one step of the raster due to {e}"
-                        "The loading will continue but this will be missing in the final cube. "
-                        f"Spectral window: {window_name}, step {i} in file: {filename}"
-                    )
-                    logger.warning(msg)
-                    continue
-                out_uncertainty = None
-                data_mask = None
-                if not memmap:
-                    data_mask = hdulist[window_fits_indices[i]].data == BAD_PIXEL_VALUE_SCALED
-                if uncertainty:
-                    out_uncertainty = calculate_uncertainty(
-                        hdulist[window_fits_indices[i]].data,
-                        readout_noise,
-                        dn_unit,
-                    )
-                if v34 and not revert_v34:
-                    times = times[::-1]
-                    data = np.flip(hdulist[window_fits_indices[i]].data, axis=0)
-                    header["PC1_3"] = 0
-                    header["PC2_3"] = -header["PC2_3"]
-                    header["PC3_2"] = -header["PC3_2"]
-                    header["CDELT3"] = -header["CDELT3"]
-                    header["CRPIX3"] = header["NAXIS3"] - header["CRPIX3"] + 1
-                    wcs = WCS(header)
+    filenames = sorted(str(f) for f in filenames)
+
+    if len(filenames) > 1:
+        date_obs_times = []
+        has_missing_date_obs = False
+        for fn in filenames:
+            with fits.open(fn, memmap=False) as h:
+                value = h[0].header.get("DATE_OBS")
+                if value:
+                    date_obs_times.append((Time(value, format="isot", scale="utc").unix, fn))
                 else:
-                    data = hdulist[window_fits_indices[i]].data
-                _set_wcs_aux_obs_coord(wcs, observer)
+                    has_missing_date_obs = True
+                    break
+        if not has_missing_date_obs:
+            filenames = [fn for _, fn in sorted(date_obs_times)]
+
+    with fits.open(filenames[0], memmap=False, do_not_scale_image_data=False) as hdulist:
+        hdulist.verify("silentfix")
+        v34 = hdulist[0].header["STEPS_AV"] < -0.01
+        primary_header = hdulist[0].header.copy()
+        obsid = primary_header.get("OBSID", None)
+        windows_in_obs = np.array(
+            [primary_header[f"TDESC{i}"] for i in range(1, primary_header["NWIN"] + 1)],
+        )
+        window_name_to_hdu = {name: i + 1 for i, name in enumerate(windows_in_obs)}
+        if not spectral_windows:
+            spectral_windows_req = list(windows_in_obs)
+        else:
+            spectral_windows_req = [spectral_windows] if isinstance(spectral_windows, str) else list(spectral_windows)
+            missing = [w for w in spectral_windows_req if w not in window_name_to_hdu]
+            if missing:
+                msg = f"Spectral windows {missing} not in file {filenames[0]}"
+                raise ValueError(msg)
+        window_fits_indices = [window_name_to_hdu[w] for w in spectral_windows_req]
+        ref_shapes = {wi: (hdulist[wi].header["NAXIS1"], hdulist[wi].header["NAXIS2"]) for wi in window_fits_indices}
+        observer = _make_observer(primary_header)
+
+    for filename in filenames[1:]:
+        with fits.open(filename, memmap=False) as h:
+            h.verify("silentfix")
+            file_startobs = h[0].header.get("STARTOBS", None)
+            file_obsid = h[0].header.get("OBSID", None)
+            if file_startobs != primary_header.get("STARTOBS"):
+                msg = (
+                    f"File {filename} has STARTOBS={file_startobs!r} which differs from "
+                    f"{filenames[0]} ({primary_header.get('STARTOBS')!r}). "
+                    "All files must belong to the same observation."
+                )
+                raise ValueError(msg)
+            if obsid is not None and file_obsid != obsid:
+                msg = (
+                    f"File {filename} has OBSID={file_obsid!r} which differs from "
+                    f"{filenames[0]} ({obsid!r}). "
+                    "All files must belong to the same observation."
+                )
+                raise ValueError(msg)
+            for wi, wname in zip(window_fits_indices, spectral_windows_req, strict=False):
+                shape = (h[wi].header["NAXIS1"], h[wi].header["NAXIS2"])
+                if shape != ref_shapes[wi]:
+                    msg = (
+                        f"Window {wname!r} in {filename} has shape {shape} "
+                        f"but expected {ref_shapes[wi]} (from {filenames[0]}). "
+                        "All files must have the same per-window dispersion/slit dimensions."
+                    )
+                    raise ValueError(msg)
+
+    data_dict = {window_name: [] for window_name in spectral_windows_req}
+
+    for filename in filenames:
+        with fits.open(filename, memmap=False, do_not_scale_image_data=False) as hdulist:
+            hdulist.verify("silentfix")
+            file_primary_header = hdulist[0].header.copy()
+            aux = hdulist[-2]
+            file_startobs = _header_time(file_primary_header, "STARTOBS", "DATE_OBS")
+
+            pc = aux.data[:, aux.header["PC2_2IX"] : aux.header["PC3_3IX"] + 1].reshape(-1, 2, 2) * u.pix
+            crval = aux.data[:, aux.header["XCENIX"] : aux.header["YCENIX"] + 1] * u.arcsec
+            times = file_startobs + TimeDelta(aux.data[:, aux.header["TIME"]] * u.s)
+            exp_fuv = aux.data[:, aux.header["EXPTIMEF"]] * u.s
+            exp_nuv = aux.data[:, aux.header["EXPTIMEN"]] * u.s
+            obs_vr = aux.data[:, aux.header["OBS_VRIX"]] * u.m / u.s
+            ophase = aux.data[:, aux.header["OPHASEIX"]] * u.one
+
+            if v34 and not revert_v34:
+                pc = pc[::-1]
+                crval = crval[::-1]
+                times = times[::-1]
+                exp_fuv = exp_fuv[::-1]
+                exp_nuv = exp_nuv[::-1]
+                obs_vr = obs_vr[::-1]
+                ophase = ophase[::-1]
+
+            flip = v34 and not revert_v34
+            t_ref = times[0]
+            dt = (times - t_ref).to_value(u.s) * u.s
+            for wi, window_name in zip(window_fits_indices, spectral_windows_req, strict=False):
+                window_header = hdulist[wi].header.copy()
+                meta = SGMeta(
+                    file_primary_header,
+                    window_name,
+                    data_shape=(window_header["NAXIS3"], window_header["NAXIS2"], window_header["NAXIS1"]),
+                )
+                basic_wcs = _create_basic_raster_wcs(
+                    window_header,
+                    aux.data,
+                    meta.spectral_band,
+                    observer,
+                    flip=flip,
+                )
+
+                is_fuv = "FUV" in meta.detector
+                dn_unit = DN_UNIT["FUV"] if is_fuv else DN_UNIT["NUV"]
+                readout_noise = READOUT_NOISE["FUV"] if is_fuv else READOUT_NOISE["NUV"]
+                exposure_times = exp_fuv if is_fuv else exp_nuv
+
+                if memmap:
+                    shape = (window_header["NAXIS3"], window_header["NAXIS2"], window_header["NAXIS1"])
+                    delayed = dask.delayed(_load_raster_window)(filename, wi, flip)
+                    data = da.from_delayed(delayed, shape=shape, dtype=np.float32)
+                    data_mask = data == BAD_PIXEL_VALUE_SCALED
+                    out_uncertainty = None
+                else:
+                    data = hdulist[wi].data.copy()
+                    if flip:
+                        data = np.flip(data, axis=0).copy()
+                    data_mask = data == BAD_PIXEL_VALUE_SCALED
+                    out_uncertainty = calculate_uncertainty(data, readout_noise, dn_unit) if uncertainty else None
+
                 cube = SpectrogramCube(
                     data,
-                    wcs=wcs,
+                    wcs=_create_raster_gwcs(
+                        window_header,
+                        pc,
+                        crval,
+                        dt,
+                        t_ref,
+                        observer,
+                        basic_wcs,
+                    ),
                     uncertainty=out_uncertainty,
                     unit=dn_unit,
                     meta=meta,
                     mask=data_mask,
+                    _basic_wcs=basic_wcs,
                 )
-                cube.extra_coords.add("time", 0, times, physical_types="time")
+                cube.extra_coords.add("time", 0, times, None)
+                cube.extra_coords.add("exposure time", 0, exposure_times, None)
+                cube.extra_coords.add("observer radial velocity", 0, obs_vr, None)
+                cube.extra_coords.add("orbital phase", 0, ophase, None)
                 data_dict[window_name].append(cube)
+
     window_data_pairs = [
-        (window_name, SpectrogramCubeSequence(data_dict[window_name], common_axis=0, meta=hdulist[0].header))
+        (window_name, SpectrogramCubeSequence(data_dict[window_name], common_axis=0, meta=primary_header))
         for window_name in spectral_windows_req
     ]
     return RasterCollection(window_data_pairs, aligned_axes=(0, 1, 2))

--- a/irispy/io/tests/test_spectrograph.py
+++ b/irispy/io/tests/test_spectrograph.py
@@ -1,8 +1,13 @@
+import warnings
+
 import numpy as np
 
 import astropy.units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.units.errors import UnitsWarning
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.wcs.utils import wcs_to_celestial_frame
 
 from sunpy.coordinates import Helioprojective
 
@@ -21,25 +26,17 @@ def test_sns_read_spectrograph_lvl2(sns_sg_file):
         "2814",
         "Mg II k 2796",
     ]
-    # Simple repr check
     assert str(raster_collection)
-    # We do not expect any metadata to be present on the collection
     assert raster_collection.meta is None
 
     si_iv = raster_collection["Si IV 1403"]
-    # Simple repr check
     assert str(si_iv)
-    # Test data only has a sequence of 1 long
     assert len(si_iv) == 1
-    # The primary fits header is attached to the sequence
     assert si_iv.meta is not None
-    # Meta is attached one level down to the individual cube for now.
     assert si_iv[0].meta is not None
     meta = si_iv[0].meta
-    assert si_iv[0].data.shape == (187, 40, 29)  # (lambda, y, x)
+    assert si_iv[0].data.shape == (187, 40, 29)
     assert np.all(si_iv[0].data.shape == meta.data_shape)
-    # Meta is both a dict with the fits header keys but also provides
-    # helper functions for specific values
     assert meta["TELESCOP"] == "IRIS" == meta.observatory
     assert meta["INSTRUME"] == "SPEC" == meta.instrument
     assert meta.detector == "FUV2"
@@ -51,7 +48,8 @@ def test_sns_read_spectrograph_lvl2(sns_sg_file):
     assert_quantity_allclose(meta.distance_to_sun, 1.00827638 * u.AU)
     assert meta.exposure_control_triggers_in_observation == 0
     assert meta.exposure_control_triggers_in_raster == 0
-    assert len(meta.fits_header) == 380 == (len(meta.keys()) + 14)  # History is missing
+    assert len(meta.fits_header) == 380
+    assert len(meta.keys()) < len(meta.fits_header)
     assert meta.fov_center == SkyCoord(
         Tx=meta.get("XCEN"),
         Ty=meta.get("YCEN"),
@@ -74,12 +72,19 @@ def test_sns_read_spectrograph_lvl2(sns_sg_file):
     assert_quantity_allclose(meta.spectral_range, (1398.60550787, 1406.03398787) * u.angstrom)
     assert meta.spectral_summing_factor == 2
     assert meta.tracking_mode_enabled is False
-
-    # TODO: Decide if I want to set observer_location, observer_radial_velocity, rsun_angular, run_meters
-    # These are more WCS properties...
     assert meta.observer_location is None
     assert meta.rsun_angular is None
     assert meta.rsun_meters is None
+    assert si_iv[0].wcs.world_n_dim == 5
+    assert si_iv[0].wcs.pixel_n_dim == 3
+    assert si_iv[0].basic_wcs is not None
+    assert si_iv[0].wcs.world_axis_physical_types == (
+        "em.wl",
+        "custom:pos.helioprojective.lon",
+        "custom:pos.helioprojective.lat",
+        "time",
+        "custom:STEP",
+    )
 
 
 def test_raster_all_files_read_spectrograph_lvl2(raster_sg_files):
@@ -95,25 +100,17 @@ def test_raster_all_files_read_spectrograph_lvl2(raster_sg_files):
         "2814",
         "Mg II k 2796",
     ]
-    # Simple repr check
     assert str(raster_collection)
-    # We do not expect any metadata to be present on the collection
     assert raster_collection.meta is None
 
     si_iv = raster_collection["Si IV 1403"]
-    # Simple repr check
     assert str(si_iv)
-    # Test data only has a sequence of 13 long
     assert len(si_iv) == 13
-    # The primary fits header is attached to the sequence
     assert si_iv.meta is not None
-    # Meta is attached one level down to the individual cube for now.
     assert si_iv[0].meta is not None
     meta = si_iv[0].meta
-    assert si_iv[0].data.shape == (8, 109, 29)  # (lambda, y, x)
+    assert si_iv[0].data.shape == (8, 109, 29)
     assert np.all(si_iv[0].data.shape == meta.data_shape)
-    # Meta is both a dict with the fits header keys but also provides
-    # helper functions for specific values
     assert meta["TELESCOP"] == "IRIS" == meta.observatory
     assert meta["INSTRUME"] == "SPEC" == meta.instrument
     assert meta.detector == "FUV2"
@@ -125,7 +122,8 @@ def test_raster_all_files_read_spectrograph_lvl2(raster_sg_files):
     assert_quantity_allclose(meta.distance_to_sun, 0.99849015 * u.AU)
     assert meta.exposure_control_triggers_in_observation == 526
     assert meta.exposure_control_triggers_in_raster == 0
-    assert len(meta.fits_header) == 412 == (len(meta.keys()) + 13)  # History is missing
+    assert len(meta.fits_header) == 412
+    assert len(meta.keys()) < len(meta.fits_header)
     assert meta.fov_center == SkyCoord(
         Tx=meta.get("XCEN"),
         Ty=meta.get("YCEN"),
@@ -148,15 +146,69 @@ def test_raster_all_files_read_spectrograph_lvl2(raster_sg_files):
     assert_quantity_allclose(meta.spectral_range, (1398.63094787, 1405.95766787) * u.angstrom)
     assert meta.spectral_summing_factor == 2
     assert meta.tracking_mode_enabled is False
-
-    # TODO: Decide if I want to set observer_location, observer_radial_velocity, rsun_angular, run_meters
-    # These are more WCS properties...
     assert meta.observer_location is None
     assert meta.rsun_angular is None
     assert meta.rsun_meters is None
+    assert si_iv[0].wcs.world_n_dim == 5
+    assert si_iv[0].wcs.pixel_n_dim == 3
+    assert si_iv.time.format == "isot"
 
 
 def test_smoke_read_spectrograph_lvl2(sns_sg_file, raster_sg_file, raster_sg_files):
     read_spectrograph_lvl2(sns_sg_file)
     read_spectrograph_lvl2(raster_sg_file)
     read_spectrograph_lvl2(raster_sg_files)
+
+
+def test_gwcs_crop_is_compatible_with_original_raster_api(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files)
+    scan = raster_collection["Si IV 1403"][0]
+
+    assert scan.time.format == "isot"
+    assert scan.basic_wcs is not None
+    spectral_coord = scan.spectral_axis[len(scan.spectral_axis) // 2]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        spectral_crop = scan.crop([SpectralCoord(spectral_coord), None], [SpectralCoord(spectral_coord), None])
+    assert spectral_crop.data.ndim == 2
+
+    frame = wcs_to_celestial_frame(scan.wcs.celestial)
+    target = SkyCoord(-8 * u.arcsec, 370 * u.arcsec, unit=u.arcsec, frame=frame)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        spectrum = scan.crop([None, target], [None, target])
+    assert spectrum.data.ndim == 1
+
+
+def test_gwcs_inverse_enables_official_crop_api(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files)
+    scan = raster_collection["Si IV 1403"][0]
+
+    start = scan.wcs.array_index_to_world(3, 50, 10)
+    stop = scan.wcs.array_index_to_world(4, 50, 10)
+
+    assert scan.wcs.world_to_array_index(*start) == (3, 50, 10)
+    assert scan.wcs.world_to_array_index(*stop) == (4, 50, 10)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        cropped = scan.crop(start, stop)
+    assert cropped.data.shape == (2,)
+
+
+def test_raster_gwcs_legacy_basic_wcs_bridge_is_limited_to_spectral_and_sky(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files)
+    scan = raster_collection["Si IV 1403"][0]
+
+    spectral, sky, _, _ = scan.wcs.array_index_to_world(3, 50, 10)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        np.testing.assert_allclose(
+            scan.wcs.world_to_pixel(spectral, sky),
+            scan.basic_wcs.world_to_pixel(spectral, sky),
+        )
+        assert scan.wcs.world_to_array_index(spectral, sky) == scan.basic_wcs.world_to_array_index(spectral, sky)

--- a/irispy/io/tests/test_spectrograph.py
+++ b/irispy/io/tests/test_spectrograph.py
@@ -1,5 +1,6 @@
 import warnings
 
+import dask.array as da
 import numpy as np
 
 import astropy.units as u
@@ -160,6 +161,18 @@ def test_smoke_read_spectrograph_lvl2(sns_sg_file, raster_sg_file, raster_sg_fil
     read_spectrograph_lvl2(raster_sg_files)
 
 
+def test_memmap_read_spectrograph_lvl2(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files, memmap=True)
+    cube = raster_collection["Si IV 1403"][0]
+    assert isinstance(cube.data, da.Array)
+    assert cube.data.shape == (8, 109, 29)
+    assert isinstance(cube.mask, da.Array)
+    assert cube.mask.shape == cube.data.shape
+    frame = cube.data[0].compute()
+    assert frame.shape == (109, 29)
+    assert frame.dtype == np.float32
+
+
 def test_gwcs_crop_is_compatible_with_original_raster_api(raster_sg_files):
     raster_collection = read_spectrograph_lvl2(raster_sg_files)
     scan = raster_collection["Si IV 1403"][0]
@@ -214,6 +227,18 @@ def test_gwcs_inverse_roundtrips_sit_and_stare_exposures(sns_sg_file):
         warnings.simplefilter("ignore", UnitsWarning)
         cropped = scan.crop(start, stop)
     assert cropped.data.shape == (2,)
+
+
+def test_scalar_slice_preserves_promoted_global_coords(sns_sg_file):
+    raster_collection = read_spectrograph_lvl2(sns_sg_file)
+    cube = raster_collection["C II 1336"][0]
+    sliced = cube[10, 20]
+
+    assert "time" in sliced.global_coords
+    assert "exposure time" in sliced.global_coords
+    assert "helioprojective" in sliced.global_coords
+    assert sliced.global_coords["time"] == cube.time[10]
+    assert sliced.exposure_time == cube.exposure_time[10]
 
 
 def test_raster_gwcs_legacy_basic_wcs_bridge_is_limited_to_spectral_and_sky(raster_sg_files):

--- a/irispy/io/tests/test_spectrograph.py
+++ b/irispy/io/tests/test_spectrograph.py
@@ -199,6 +199,23 @@ def test_gwcs_inverse_enables_official_crop_api(raster_sg_files):
     assert cropped.data.shape == (2,)
 
 
+def test_gwcs_inverse_roundtrips_sit_and_stare_exposures(sns_sg_file):
+    raster_collection = read_spectrograph_lvl2(sns_sg_file)
+    scan = raster_collection["Si IV 1403"][0]
+
+    start = scan.wcs.array_index_to_world(3, 20, 10)
+    stop = scan.wcs.array_index_to_world(4, 20, 10)
+
+    assert scan.wcs.world_to_array_index(*start) == (3, 20, 10)
+    assert scan.wcs.world_to_array_index(*stop) == (4, 20, 10)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        cropped = scan.crop(start, stop)
+    assert cropped.data.shape == (2,)
+
+
 def test_raster_gwcs_legacy_basic_wcs_bridge_is_limited_to_spectral_and_sky(raster_sg_files):
     raster_collection = read_spectrograph_lvl2(raster_sg_files)
     scan = raster_collection["Si IV 1403"][0]
@@ -212,3 +229,19 @@ def test_raster_gwcs_legacy_basic_wcs_bridge_is_limited_to_spectral_and_sky(rast
             scan.basic_wcs.world_to_pixel(spectral, sky),
         )
         assert scan.wcs.world_to_array_index(spectral, sky) == scan.basic_wcs.world_to_array_index(spectral, sky)
+
+
+def test_raster_gwcs_matches_basic_wcs_forward_world_coordinates(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files)
+    scan = raster_collection["Si IV 1403"][0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        for array_index in ((0, 50, 3), (3, 50, 10), (7, 80, 20)):
+            spectral, sky, _, _ = scan.wcs.array_index_to_world(*array_index)
+            basic_spectral, basic_sky = scan.basic_wcs.array_index_to_world(*array_index)
+
+            assert_quantity_allclose(spectral.to(u.nm), basic_spectral.to(u.nm))
+            assert_quantity_allclose(sky.Tx.to(u.arcsec), basic_sky.Tx.to(u.arcsec), atol=10 * u.arcsec)
+            assert_quantity_allclose(sky.Ty.to(u.arcsec), basic_sky.Ty.to(u.arcsec), atol=1 * u.arcsec)

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -1,4 +1,5 @@
 import textwrap
+from copy import deepcopy
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -59,6 +60,27 @@ class SpectrogramCube(SpecCube):
         super().__init__(data, wcs, unit=unit, uncertainty=uncertainty, mask=mask, meta=meta, copy=copy, **kwargs)
 
     @property
+    def exposure_time(self):
+        try:
+            return super().exposure_time
+        except ValueError:
+            # After scalar slicing, ndcube promotes axis-specific extra_coords to
+            # global_coords. Check there first before falling back to FITS EXPTIME.
+            gc = self.global_coords
+            if gc:
+                from sunraster.spectrogram import SUPPORTED_EXPOSURE_NAMES  # NOQA: PLC0415
+
+                for name in SUPPORTED_EXPOSURE_NAMES:
+                    if name in gc:
+                        return gc[name]
+            exptime = self.meta.get("EXPTIME")
+            if exptime is not None:
+                import astropy.units as u  # NOQA: PLC0415
+
+                return exptime * u.s
+            raise
+
+    @property
     def time(self):
         time = super().time
         if time.format == "jd":
@@ -87,6 +109,66 @@ class SpectrogramCube(SpecCube):
                 physical_type = physical_type[0]
             new_sc.global_coords.add(name, physical_type, coord)
         return new_sc
+
+    def _exposure_time_array_axis(self):
+        exposure_time_name = self._exposure_time_name
+        extra_coord_names = tuple(self.extra_coords.keys())
+        if exposure_time_name is None and "exposure time" in extra_coord_names:
+            exposure_time_name = "exposure time"
+        if exposure_time_name is not None and exposure_time_name in extra_coord_names:
+            mapping = self.extra_coords[exposure_time_name].mapping
+            if len(mapping) == 1:
+                return self.data.ndim - 1 - int(mapping[0])
+        if self._exposure_time_name is not None and self._exposure_time_loc is not None:
+            exposure_axis = self._get_axis_coord_index(self._exposure_time_name, self._exposure_time_loc)
+            if isinstance(exposure_axis, tuple):
+                exposure_axis = exposure_axis[0]
+            return int(exposure_axis)
+        matching_axes = [
+            axis for axis, size in enumerate(self.data.shape) if size == np.asarray(self.exposure_time).shape[0]
+        ]
+        if len(matching_axes) == 1:
+            return matching_axes[0]
+        msg = "Unable to determine exposure time array axis."
+        raise ValueError(msg)
+
+    def apply_exposure_time_correction(self, undo=False, force=False):  # noqa: FBT002
+        try:
+            return super().apply_exposure_time_correction(undo=undo, force=force)
+        except (TypeError, ValueError):
+            from sunraster.spectrogram import (  # NOQA: PLC0415
+                _calculate_exposure_time_correction,
+                _uncalculate_exposure_time_correction,
+            )
+
+            exposure_time_s = self.exposure_time.to(u.s).value
+            if not np.isscalar(exposure_time_s):
+                exposure_axis = self._exposure_time_array_axis()
+                item = [np.newaxis] * self.data.ndim
+                item[exposure_axis] = slice(None)
+                exposure_time_s = exposure_time_s[tuple(item)]
+            if undo is True:
+                new_data, new_uncertainty, new_unit = _uncalculate_exposure_time_correction(
+                    self.data,
+                    self.uncertainty,
+                    self.unit,
+                    exposure_time_s,
+                    force=force,
+                )
+            else:
+                new_data, new_uncertainty, new_unit = _calculate_exposure_time_correction(
+                    self.data,
+                    self.uncertainty,
+                    self.unit,
+                    exposure_time_s,
+                    force=force,
+                )
+            new_cube = deepcopy(self)
+            new_cube._data = new_data
+            new_cube._uncertainty = new_uncertainty
+            new_cube._extra_coords = self.extra_coords
+            new_cube._unit = new_unit
+            return new_cube
 
     @staticmethod
     def _slice_or_index(lower, upper, keepdims):

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -3,6 +3,8 @@ import textwrap
 import matplotlib.pyplot as plt
 import numpy as np
 
+import astropy.units as u
+
 from ndcube import NDCollection
 from sunpy import log as logger
 from sunraster import SpectrogramCube as SpecCube
@@ -53,18 +55,81 @@ class SpectrogramCube(SpecCube):
     """
 
     def __init__(self, data, wcs, uncertainty, unit, meta, *, mask=None, copy=False, **kwargs) -> None:
+        self._basic_wcs = kwargs.pop("_basic_wcs", None)
         super().__init__(data, wcs, unit=unit, uncertainty=uncertainty, mask=mask, meta=meta, copy=copy, **kwargs)
+
+    @property
+    def time(self):
+        time = super().time
+        if time.format == "jd":
+            time = time.copy()
+            time.format = "isot"
+        return time
 
     def __getitem__(self, item):
         result = super().__getitem__(item)
-        return SpectrogramCube(
+        extra_coords = result.extra_coords if not result.extra_coords.is_empty else None
+        new_sc = SpectrogramCube(
             result.data,
             result.wcs,
             result.uncertainty,
             result.unit,
             result.meta,
             mask=result.mask,
+            extra_coords=extra_coords,
+            _basic_wcs=self._basic_wcs,
         )
+        # ndcube promotes scalar-indexed extra_coords to global_coords.
+        # Copy them explicitly so they are bound to the new cube, not result.
+        for name, coord in result.global_coords.items():
+            physical_type = result.global_coords.physical_types[name]
+            if isinstance(physical_type, tuple):
+                physical_type = physical_type[0]
+            new_sc.global_coords.add(name, physical_type, coord)
+        return new_sc
+
+    @staticmethod
+    def _slice_or_index(lower, upper, keepdims):
+        if lower == upper and not keepdims:
+            return lower
+        return slice(lower, upper + 1)
+
+    def _nearest_spatial_indices(self, coordinate):
+        sample_world = self.wcs.pixel_to_world(*([0] * self.wcs.pixel_n_dim))
+        sample_world = sample_world if isinstance(sample_world, (list, tuple)) else [sample_world]
+        frame = next(world.frame for world in sample_world if hasattr(world, "frame"))
+        coord = coordinate.transform_to(frame)
+        lon = self.axis_world_coords_values("custom:pos.helioprojective.lon")[0].to_value(u.arcsec)
+        lat = self.axis_world_coords_values("custom:pos.helioprojective.lat")[0].to_value(u.arcsec)
+        distance = (lon - coord.Tx.to_value(u.arcsec)) ** 2 + (lat - coord.Ty.to_value(u.arcsec)) ** 2
+        return np.unravel_index(np.nanargmin(distance), distance.shape)
+
+    def _manual_crop_item(self, points, keepdims):
+        if self.data.ndim != 3 or len(points) != 2:
+            return None
+        if any(not isinstance(point, (tuple, list)) or len(point) != 2 for point in points):
+            return None
+
+        spectral_points = [point[0] for point in points if point[0] is not None]
+        spatial_points = [point[1] for point in points if point[1] is not None]
+        if not spectral_points and not spatial_points:
+            return None
+
+        item = [slice(None)] * self.data.ndim
+        if spectral_points:
+            spectral_axis = self.spectral_axis.to_value(self.spectral_axis.unit)
+            spectral_indices = [
+                int(np.nanargmin(np.abs(spectral_axis - spectral_point.to_value(self.spectral_axis.unit))))
+                for spectral_point in spectral_points
+            ]
+            item[2] = self._slice_or_index(min(spectral_indices), max(spectral_indices), keepdims)
+        if spatial_points:
+            spatial_indices = [self._nearest_spatial_indices(spatial_point) for spatial_point in spatial_points]
+            raster_indices = [idx[0] for idx in spatial_indices]
+            slit_indices = [idx[1] for idx in spatial_indices]
+            item[0] = self._slice_or_index(min(raster_indices), max(raster_indices), keepdims)
+            item[1] = self._slice_or_index(min(slit_indices), max(slit_indices), keepdims)
+        return tuple(item)
 
     def __repr__(self) -> str:
         return f"{object.__repr__(self)}\n{self!s}"
@@ -75,9 +140,20 @@ class SpectrogramCube(SpecCube):
         if self.global_coords and "time" in self.global_coords:
             instance_start = self.global_coords["time"].min().isot
             instance_end = self.global_coords["time"].max().isot
-        elif self.extra_coords and self.axis_world_coords("time", wcs=self.extra_coords):
-            instance_start = self.axis_world_coords("time", wcs=self.extra_coords)[0].min().isot
-            instance_end = self.axis_world_coords("time", wcs=self.extra_coords)[0].max().isot
+        elif self.extra_coords:
+            try:
+                extra_coord_time = self.axis_world_coords("time", wcs=self.extra_coords)
+            except ValueError:
+                extra_coord_time = None
+            if extra_coord_time:
+                instance_start = extra_coord_time[0].min().isot
+                instance_end = extra_coord_time[0].max().isot
+        if instance_start is None or instance_end is None:
+            try:
+                instance_start = self.time.min().isot
+                instance_end = self.time.max().isot
+            except ValueError:
+                pass
         return textwrap.dedent(
             f"""
             SpectrogramCube
@@ -105,6 +181,23 @@ class SpectrogramCube(SpecCube):
         ax = IRISPlotter(ndcube=self).plot(*args, **kwargs)
         set_axis_properties(ax)
         return ax
+
+    @property
+    def basic_wcs(self):
+        """
+        Return a standard astropy WCS, when one is available alongside the gWCS.
+        """
+        return self._basic_wcs
+
+    def crop(self, *points, wcs=None, keepdims=False):
+        manual_item = None
+        if wcs is None:
+            # Keep supporting the pre-gWCS raster shorthand where crop points
+            # are just (spectral, sky) pairs with omitted time/step entries.
+            manual_item = self._manual_crop_item(points, keepdims)
+        if manual_item is not None:
+            return self[manual_item]
+        return super().crop(*points, wcs=wcs, keepdims=keepdims)
 
     def remove_cosmic_rays(
         self,

--- a/irispy/tests/test_spectrograph.py
+++ b/irispy/tests/test_spectrograph.py
@@ -19,9 +19,9 @@ def test_fits_data_comparison(sns_sg_file):
         data1 = copy.deepcopy(hdulist[1].data)
         data2 = copy.deepcopy(hdulist[2].data)
         data3 = copy.deepcopy(hdulist[3].data)
-        np.testing.assert_array_almost_equal(iris_l2_test_raster[spectral_window1].data[0].data, data1)
-        np.testing.assert_array_almost_equal(iris_l2_test_raster[spectral_window2].data[0].data, data2)
-        np.testing.assert_array_almost_equal(iris_l2_test_raster[spectral_window3].data[0].data, data3)
+        np.testing.assert_array_almost_equal(iris_l2_test_raster[spectral_window1][0].data, data1)
+        np.testing.assert_array_almost_equal(iris_l2_test_raster[spectral_window2][0].data, data2)
+        np.testing.assert_array_almost_equal(iris_l2_test_raster[spectral_window3][0].data, data3)
 
 
 def test_spectrogram_cube_remove_cosmic_rays(sns_sg_file, monkeypatch):
@@ -61,8 +61,8 @@ def test_spectrogram_cube_remove_cosmic_rays(sns_sg_file, monkeypatch):
     assert captured["max_iters"] == 5
     assert captured["method_kwargs"]["batch_size"] == 16
     np.testing.assert_array_equal(captured["mask"], cube.mask)
-    # WCS is deep-copied, so check equivalence not identity
-    assert dict(cleaned_cube.wcs.to_header()) == dict(cube.wcs.to_header())
+    # WCS is preserved by to_nddata; gWCS has no to_header(), so compare by identity/type.
+    assert type(cleaned_cube.wcs) is type(cube.wcs)
     assert list(cleaned_cube.global_coords) == list(cube.global_coords)
     assert cleaned_cube.unit == cube.unit
     # meta is an NDMeta subclass that may contain arrays; compare keys only

--- a/irispy/utils/spectrograph.py
+++ b/irispy/utils/spectrograph.py
@@ -21,6 +21,104 @@ __all__ = [
 ]
 
 
+def _get_wcs_pixel_scales(cube):
+    """
+    Return ``(spectral_dispersion_per_pixel, slit_pixel_scale)`` from any SpectrogramCube WCS.
+
+    Works with astropy FITS WCS, ndcube SlicedLowLevelWCS, and gWCS objects.
+
+    Returns
+    -------
+    spectral_dispersion_per_pixel : `~astropy.units.Quantity`
+        Wavelength covered per dispersion pixel (e.g. Angstrom/pix).
+    slit_pixel_scale : `~astropy.units.Quantity`
+        Angular size of one slit pixel (e.g. arcsec/pix).
+    """
+    if hasattr(cube.wcs, "wcs"):
+        wcs = cube.wcs.wcs
+        spectral_idx = np.where(np.array(wcs.ctype) == "WAVE")[0][0]
+        lat_idx = np.arange(len(wcs.ctype))[["HPLT" in c for c in wcs.ctype]][0]
+        return (
+            wcs.cdelt[spectral_idx] * wcs.cunit[spectral_idx],
+            wcs.cdelt[lat_idx] * wcs.cunit[lat_idx],
+        )
+    try:
+        wcs = unwrap_wcs_to_fitswcs(cube.wcs)[0].wcs
+        spectral_idx = np.where(np.array(wcs.ctype) == "WAVE")[0][0]
+        lat_idx = np.arange(len(wcs.ctype))[["HPLT" in c for c in wcs.ctype]][0]
+        return (
+            wcs.cdelt[spectral_idx] * wcs.cunit[spectral_idx],
+            wcs.cdelt[lat_idx] * wcs.cunit[lat_idx],
+        )
+    except TypeError:
+        pass
+
+    from dkist.wcs.models import VaryingCelestialTransform  # NOQA: PLC0415
+
+    def _find_vct(model):
+        if isinstance(model, VaryingCelestialTransform):
+            return model
+        for attr in ("left", "right"):
+            sub = getattr(model, attr, None)
+            if sub is not None:
+                found = _find_vct(sub)
+                if found is not None:
+                    return found
+        return None
+
+    underlying = cube.wcs
+    for _ in range(10):
+        if hasattr(underlying, "forward_transform"):
+            break
+        if hasattr(underlying, "low_level_wcs"):
+            underlying = underlying.low_level_wcs
+        elif hasattr(underlying, "_wcs"):
+            underlying = underlying._wcs
+        else:
+            break
+
+    if hasattr(underlying, "forward_transform"):
+        vct = _find_vct(underlying.forward_transform)
+        if vct is not None:
+            slit_scale = abs(vct.cdelt.quantity[0]).to(u.arcsec / u.pix).value * u.arcsec
+            spectral = next(
+                (
+                    model
+                    for model in underlying.forward_transform
+                    if hasattr(model, "slope")
+                    and getattr(model, "slope", None) is not None
+                    and hasattr(model.slope, "unit")
+                    and model.slope.unit.is_equivalent(u.AA / u.pix)
+                ),
+                None,
+            )
+            if spectral is not None:
+                disp = abs(spectral.slope.quantity).to(u.AA / u.pix)
+                return disp.value * u.AA, slit_scale.to(u.arcsec)
+
+    n_pix = cube.wcs.pixel_n_dim
+    p0 = [0.0] * n_pix
+    p_d = list(p0)
+    p_d[0] = 1.0
+    p_s = list(p0)
+    p_s[min(1, n_pix - 1)] = 1.0
+    w0 = cube.wcs.pixel_to_world(*p0)
+    w_d = cube.wcs.pixel_to_world(*p_d)
+    w_s = cube.wcs.pixel_to_world(*p_s)
+
+    def _to_list(world):
+        return list(world) if isinstance(world, (list, tuple)) else [world]
+
+    w0l, wdl, wsl = _to_list(w0), _to_list(w_d), _to_list(w_s)
+    spectral_dispersion = next(
+        abs((wc1 - wc0).to(u.AA))
+        for wc0, wc1 in zip(w0l, wdl, strict=False)
+        if hasattr(wc0, "unit") and wc0.unit.is_equivalent(u.AA)
+    )
+    sky0, sky1 = next((wc0, wc1) for wc0, wc1 in zip(w0l, wsl, strict=False) if hasattr(wc0, "separation"))
+    return spectral_dispersion, sky0.separation(sky1).to(u.arcsec)
+
+
 def radiometric_calibration(
     cube: SpectrogramCube | SpectrogramCubeSequence,
 ) -> SpectrogramCube | SpectrogramCubeSequence:
@@ -64,14 +162,8 @@ def radiometric_calibration(
     if isinstance(cube, SpectrogramCubeSequence):
         return SpectrogramCubeSequence([radiometric_calibration(c) for c in cube])
     detector_type = cube.meta.detector
-    underlying_wcs = unwrap_wcs_to_fitswcs(cube.wcs)[0].wcs if not hasattr(cube.wcs, "wcs") else cube.wcs.wcs
-    # Get spectral dispersion per pixel.
-    spectral_wcs_index = np.where(np.array(underlying_wcs.ctype) == "WAVE")[0][0]
-    spectral_dispersion_per_pixel = underlying_wcs.cdelt[spectral_wcs_index] * underlying_wcs.cunit[spectral_wcs_index]
-    # Get solid angle from slit width for a pixel.
-    lat_wcs_index = ["HPLT" in c for c in underlying_wcs.ctype]
-    lat_wcs_index = np.arange(len(underlying_wcs.ctype))[lat_wcs_index][0]
-    solid_angle = underlying_wcs.cdelt[lat_wcs_index] * underlying_wcs.cunit[lat_wcs_index] * SLIT_WIDTH
+    spectral_dispersion_per_pixel, slit_pixel_scale = _get_wcs_pixel_scales(cube)
+    solid_angle = slit_pixel_scale * SLIT_WIDTH
     # Get wavelength for each pixel.
     wavelength_axis_index = next(
         axis
@@ -81,14 +173,12 @@ def radiometric_calibration(
     wavelength = cube.axis_world_coords(wavelength_axis_index)[0]
     time_obs = cube.meta.date_reference
     iris_response = get_latest_response(time_obs)
-    exp_corrected_cube = cube.apply_exposure_time_correction()
+    corrected_cube = cube.apply_exposure_time_correction()
+    unit_factor = corrected_cube.unit.to(u.photon / u.s)
     # Convert to radiance units.
-    data_quantities = (exp_corrected_cube.data * exp_corrected_cube.unit.to(u.photon / u.s) * (u.photon / u.s),)
-    if exp_corrected_cube.uncertainty is not None:
-        uncertainty = (
-            exp_corrected_cube.uncertainty.array * exp_corrected_cube.unit.to(u.photon / u.s) * (u.photon / u.s)
-        )
-        data_quantities += (uncertainty,)
+    data_quantities = (corrected_cube.data * unit_factor * (u.photon / u.s),)
+    if corrected_cube.uncertainty is not None:
+        data_quantities += (corrected_cube.uncertainty.array * unit_factor * (u.photon / u.s),)
     new_data_quantities = convert_photons_per_sec_to_radiance(
         data_quantities=data_quantities,
         iris_response=iris_response,
@@ -100,16 +190,19 @@ def radiometric_calibration(
     new_data = new_data_quantities[0].value
     new_uncertainty = new_data_quantities[1].value if len(new_data_quantities) > 1 else None
     new_unit = new_data_quantities[0].unit
-    new_cube = SpectrogramCube(
-        new_data,
-        cube.wcs,
-        new_uncertainty,
-        new_unit,
-        cube.meta,
-        mask=cube.mask,
+    new_cube_kwargs = {
+        "data": new_data,
+        "uncertainty": new_uncertainty,
+        "unit": new_unit,
+        "mask": "copy",
+        "nddata_type": type(cube),
+        "extra_coords": "copy",
+        "global_coords": "copy",
+        "_basic_wcs": "copy",
+    }
+    return cube.to_nddata(
+        **new_cube_kwargs,
     )
-    new_cube._extra_coords = cube.extra_coords
-    return new_cube
 
 
 def convert_photons_per_sec_to_radiance(

--- a/irispy/utils/tests/test_spectrograph.py
+++ b/irispy/utils/tests/test_spectrograph.py
@@ -12,7 +12,7 @@ from irispy.io.utils import read_files
 from irispy.spectrograph import SpectrogramCube, SpectrogramCubeSequence
 from irispy.utils.constants import SLIT_WIDTH
 from irispy.utils.response import get_latest_response
-from irispy.utils.spectrograph import calculate_dn_to_radiance_factor, radiometric_calibration
+from irispy.utils.spectrograph import _get_wcs_pixel_scales, calculate_dn_to_radiance_factor, radiometric_calibration
 
 
 @pytest.fixture
@@ -33,9 +33,9 @@ def test_calculate_dn_to_radiance_factor(sns_sg_file, idl_input_rad_cal, idl_out
     idl_wavelength = idl_input_rad_cal["wavelength"] * u.Angstrom
     idl_factor_cgs = idl_output_rad_cal["factor"]
 
-    spectral_dispersion_per_pixel = cube.wcs.wcs.cdelt[0] * cube.wcs.wcs.cunit[0]
+    spectral_dispersion_per_pixel, slit_pixel_scale = _get_wcs_pixel_scales(cube)
     # The slit width is divided by 2 in the IDL code, unsure why.
-    solid_angle = cube.wcs.wcs.cdelt[1] * cube.wcs.wcs.cunit[1] * (SLIT_WIDTH / 2)
+    solid_angle = slit_pixel_scale * (SLIT_WIDTH / 2)
     iris_response = get_latest_response(parse_time("2025-01-01"))
     factor = calculate_dn_to_radiance_factor(
         iris_response=iris_response,
@@ -99,12 +99,42 @@ def test_radiometric_calibration_single_sliced_raster_cube(sns_sg_file):
     assert np.array_equal(calibrated_slice.mask, expected_slice.mask)
 
 
+def test_apply_exposure_time_correction_single_sliced_raster_cube(sns_sg_file):
+    raster_collection = read_files(sns_sg_file)
+    cube = raster_collection["C II 1336"][0]
+    cube_slice = cube[10, :, :]
+
+    corrected_full_cube = cube.apply_exposure_time_correction()
+    corrected_slice = cube_slice.apply_exposure_time_correction()
+    expected_slice = corrected_full_cube[10, :, :]
+
+    assert corrected_slice.unit == expected_slice.unit
+    np.testing.assert_allclose(corrected_slice.data, expected_slice.data)
+
+
+def test_radiometric_calibration_dask_backed(raster_sg_files):
+    from irispy.io.spectrograph import read_spectrograph_lvl2  # NOQA: PLC0415
+
+    eager_sequence = read_spectrograph_lvl2(raster_sg_files)["Si IV 1403"]
+    dask_sequence = read_spectrograph_lvl2(raster_sg_files, memmap=True)["Si IV 1403"]
+    result_eager = radiometric_calibration(eager_sequence[0])
+    result_dask = radiometric_calibration(dask_sequence[0])
+
+    assert result_dask.unit == u.erg / (u.cm**2 * u.s * u.sr * u.AA)
+    assert result_dask.data.shape == dask_sequence[0].data.shape
+
+    frame_dask = np.asarray(result_dask.data[0])
+    frame_eager = result_eager.data[0]
+    assert frame_dask.shape == frame_eager.shape
+    np.testing.assert_allclose(frame_dask, frame_eager, rtol=1e-5)
+
+
 def test_convert_photons_per_sec_to_radiance_vs_peter_young(sns_sg_file):
     raster_collection = read_files(sns_sg_file)
     cube = raster_collection["C II 1336"][0]
 
-    solid_angle = cube.wcs.wcs.cdelt[1] * cube.wcs.wcs.cunit[1] * (SLIT_WIDTH)
-    spectral_dispersion_per_pixel = cube.wcs.wcs.cdelt[0] * cube.wcs.wcs.cunit[0]
+    spectral_dispersion_per_pixel, slit_pixel_scale = _get_wcs_pixel_scales(cube)
+    solid_angle = slit_pixel_scale * SLIT_WIDTH
     iris_response = get_latest_response(parse_time("2014-09-10"))
     factor = calculate_dn_to_radiance_factor(
         iris_response=iris_response,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,15 +43,17 @@ dependencies = [
 ]
 
 optional-dependencies.all = [ "irispy-lmsal" ]
+optional-dependencies.memmap = [
+    "dask[distributed,array]>=2024.1.0",
+]
 optional-dependencies.cosmic-rays = [
   "astroscrappy",
   "rsliding",
 ]
-optional-dependencies.dev = [ "irispy-lmsal[cosmic-rays,docs,tests]" ]
+optional-dependencies.dev = [ "irispy-lmsal[cosmic-rays,memmap,docs,tests]" ]
 optional-dependencies.docs = [
   "aiapy",
-  "dask[distributed]",
-  "irispy-lmsal[cosmic-rays]",
+  "irispy-lmsal[cosmic-rays,memmap]",
   "pooch",
   "sphinx",
   "sphinx-automodapi",
@@ -63,7 +65,7 @@ optional-dependencies.docs = [
   "sunpy-sphinx-theme",
 ]
 optional-dependencies.tests = [
-  "irispy-lmsal[cosmic-rays]",
+  "irispy-lmsal[cosmic-rays,memmap]",
   "pooch",
   "pytest-astropy",
   "pytest-mpl",


### PR DESCRIPTION
## Summary by Sourcery

Introduce a gWCS-based WCS representation for IRIS spectrograph raster data while preserving legacy raster APIs, improving time/metadata handling, and adding lazy multi-file loading and validation.

New Features:
- Provide an IRIS raster gWCS with explicit wavelength, helioprojective longitude/latitude, time, and scan-step world axes.
- Expose a basic astropy WCS alongside the new raster gWCS and bridge legacy spectral+sky queries to it for backward compatibility.
- Extend SpectrogramCube with a time property that returns times in ISOT format and a basic_wcs accessor.
- Support legacy raster crop shorthand by manually mapping (spectral, sky) coordinate pairs onto the appropriate pixel indices when no WCS is given.
- Enable lazy, per-window raster data loading via Dask when memmap=True, including on-demand BSCALE/BZERO application and bad-pixel masking.

Enhancements:
- Refine raster file handling by sorting inputs by observation start time when possible and validating that all files belong to the same observation and share compatible window shapes.
- Factor raster WCS preparation into helper functions that normalize headers, construct observer coordinates, and build both basic and gWCS objects.
- Add richer extra_coords for raster cubes, including exposure time, observer radial velocity, and orbital phase, and ensure metadata from the primary header is attached at the sequence level.
- Ensure SpectrogramCube slicing, cropping, and string representation correctly preserve and report global and extra coordinates with more robust time derivation.
- Adjust tests to reflect the new gWCS representation, updated shapes and metadata expectations, and preservation of WCS objects through processing.

Tests:
- Add tests exercising gWCS-based cropping for spectral and spatial slices to ensure compatibility with the original raster crop API.
- Add round-trip tests for the gWCS inverse mapping, including sit-and-stare exposures and verification against the basic WCS for selected pixels.
- Add tests that verify legacy world_to_pixel and world_to_array_index calls are delegated to the basic WCS only for spectral+sky inputs.
- Update existing spectrograph IO and SpectrogramCube tests to use the new access patterns, time handling, metadata size expectations, and WCS preservation semantics.