### PR TITLE
Add raster spectrograph gWCS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 exclude: "(.*/)?CITATION.rst$|.*(.fits|.fts|.fit|.header|.txt|tca.*|extern.*|irispy/extern)$"
 repos:
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.23.1
+    rev: v1.24.1
     hooks:
       - id: zizmor
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.9"
+    rev: "v0.15.11"
     hooks:
       - id: ruff
         args: ["--fix", "--unsafe-fixes"]
@@ -50,7 +50,7 @@ repos:
         types_or: [python, rst, yaml, json]
   # See https://github.com/python-trio/trio/pull/3255
   -   repo: https://github.com/adhtruong/mirrors-typos
-      rev: v1.45.0
+      rev: v1.45.1
       hooks:
       - id: typos
         exclude: *exclude_dirs

--- a/changelog/119.breaking.rst
+++ b/changelog/119.breaking.rst
@@ -1,0 +1,3 @@
+Raster spectrograph ``crop`` calls now require full gWCS world tuples instead of the older
+two-component shorthand, and the raster examples and tutorials show how to build those tuples with
+``cube.wcs.array_index_to_world``.

--- a/changelog/119.feature.rst
+++ b/changelog/119.feature.rst
@@ -1,0 +1,2 @@
+Replaced the raster WCS with a gWCS implementation.
+This mirrors the SJI but allows for more flexible handling of the WCS.

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -7,18 +7,6 @@ Known Issues
 This page documents commonly known issues.
 "Issues" here is defined broadly and refers to oddities or specifics of how ``irispy`` or the Python ecosystem works that can and will catch users off guard.
 
-Per-exposure WCS metadata
-=========================
-
-The IRIS FITS files contain the per-exposure WCS metadata (reference coordinate and PCij matrix) in an extension, while the primary header has only values averaged over the observation.
-For example, OBS 4204700138 SJI file, ``CRVAL`` in the primary header is (1.93840, 1.96290), but the reference coordinate
-is actually (-3.56638378, 1.69258388), which is retrieved from the appropriate index in the ``XCENIX``/``YCENIX`` arrays in the extension.
-
-This was (and partially still is) a problem for the ``irispy`` package, which assumed that the reference coordinate is the same for all exposures.
-This has been addressed by the SJI reader but not fully by the spectrograph reader.
-
-In the future, the goal is to create a gWCS to account for this.
-
 Spectrogram WCS
 ===============
 
@@ -33,3 +21,60 @@ Using equation 187 in `Calabretta & Greisen 2002 <https://www.aanda.org/articles
 
 Note that since these pixels are extremely rectangular, with an aspect ratio of ~3e-10, the cross terms in the PCij matrix are quite small: -3.4e-12 and -3.8e-7.
 Hopefully, 64-bit floats have enough precision to enable this to work all of the time.
+
+Updating Raster ``crop`` Calls
+==============================
+
+IRIS spectrograph rasters now use a full gWCS, so raster crops must be written against the world-object order returned by ``cube.wcs.array_index_to_world(step, slit, spectral)``.
+For rasters that order is ``(spectral, skycoord, time, scan_step)``.
+
+The old two-component shorthand is no longer supported:
+
+.. code-block:: python
+
+   cube.crop([SpectralCoord(140.277 * u.nm), None], [SpectralCoord(140.277 * u.nm), None])
+   cube.crop([None, target_skycoord], [None, target_skycoord])
+
+Use one of these patterns instead.
+
+Crop a spectroheliogram at one wavelength
+-----------------------------------------
+
+If you only want to constrain wavelength, pass the full four-component raster world tuple and use ``None`` for the unconstrained axes:
+
+.. code-block:: python
+
+   line_core = SpectralCoord(140.277 * u.nm)
+   image = cube.crop(
+       [line_core, None, None, None],
+       [line_core, None, None, None],
+   )
+
+
+Crop a subcube from known raster corners
+----------------------------------------
+
+If you already know the pixel corners you want, convert them to full world tuples and pass those directly into ``crop``:
+
+.. code-block:: python
+
+   start = cube.wcs.array_index_to_world(50, 200, 10)
+   stop = cube.wcs.array_index_to_world(150, 600, 25)
+   subcube = cube.crop(start, stop)
+
+Extract a spectrum at a sky position
+------------------------------------
+
+If you start from a ``SkyCoord``, first locate the nearest raster pixel on the sky grid, then convert that pixel back into the full world tuples expected by ``crop``:
+
+.. code-block:: python
+
+   target = SkyCoord(-338 * u.arcsec, 275 * u.arcsec, frame=target_frame)
+   lon = cube.axis_world_coords_values("custom:pos.helioprojective.lon")[0].to_value(u.arcsec)
+   lat = cube.axis_world_coords_values("custom:pos.helioprojective.lat")[0].to_value(u.arcsec)
+   distance = (lon - target.Tx.to_value(u.arcsec)) ** 2 + (lat - target.Ty.to_value(u.arcsec)) ** 2
+   step_index, slit_index = np.unravel_index(np.nanargmin(distance), distance.shape)
+
+   start = cube.wcs.array_index_to_world(step_index, slit_index, 0)
+   stop = cube.wcs.array_index_to_world(step_index, slit_index, cube.data.shape[-1] - 1)
+   spectrum = cube.crop(start, stop)

--- a/examples/analysis/00_work_with_rasters.py
+++ b/examples/analysis/00_work_with_rasters.py
@@ -71,13 +71,26 @@ fig = plt.figure()
 mg_ii.plot(fig=fig)
 
 ###############################################################################
-# If we want to "raster" over wavelength, we can do the following
+# If we want to "raster" over wavelength, we can do the following:
 
 fig = plt.figure()
 # This will also "transpose" the data but this is only for visualization purposes
 # We have to set the vmin and vmax, as by default "plot" works out the
 # vmin,vmax from the first slice which in this case is 0.
+# By default, the raster scan axis is shown as helioprojective longitude.
 mg_ii.plot(fig=fig, plot_axes=["x", "y", None], vmin=0, vmax=1000)
+
+###############################################################################
+# If you want to view the raster scan as time instead, select time explicitly.
+
+fig = plt.figure()
+mg_ii.plot(
+    fig=fig,
+    plot_axes=["x", "y", None],
+    axes_coordinates=["time", "custom:pos.helioprojective.lat", None],
+    vmin=0,
+    vmax=1000,
+)
 
 ###############################################################################
 # This object is sliceable, so we can do things like this:
@@ -90,15 +103,6 @@ ax = fig.add_subplot(111, projection=mg_ii[120, 200].wcs)
 mg_ii[120, 200].plot(axes=ax)
 
 ###############################################################################
-# We can also plot using the data directly. We can read the wavelengths of the
-# Mg window by calling `ndcube.NDCube.axis_world_coords` for "wl" (wavelength), and redo the plot.
-
-(mg_wave,) = mg_ii.axis_world_coords("wl")
-
-fig, ax = plt.subplots()
-ax.plot(mg_wave.to("AA"), mg_ii.data[120, 200])
-
-###############################################################################
 # When we use the underlying data directly, we lose all the metadata and WCS information.
 #
 # If you are unfamiliar with WCS, the following links are quite useful:
@@ -109,38 +113,56 @@ ax.plot(mg_wave.to("AA"), mg_ii.data[120, 200])
 # Some of the higher-level utilities are via ndcube, e.g., coordinate transformations: https://docs.sunpy.org/projects/ndcube/en/stable/explaining_ndcube/coordinates.html.
 #
 # Now, let's take a look at the WCS information.
-# For example, what is the wavelength position that corresponds to Mg II k core (279.63 nm)?
+# For raster data, the full gWCS uses ``(spectral, sky, time, scan_step)``
+# world inputs, so wavelength-plus-sky queries go through ``basic_wcs``.
+# For example, what is the wavelength position that corresponds to
+# Mg II k core (279.63 nm)?
 
-iris_observer = wcs_to_celestial_frame(mg_ii.wcs.celestial).observer
+iris_observer = wcs_to_celestial_frame(mg_ii.basic_wcs.celestial).observer
 iris_frame = Helioprojective(observer=iris_observer)
-wcs_loc = mg_ii.wcs.world_to_pixel(
+step_index = mg_ii.data.shape[0] // 2
+slit_index = mg_ii.data.shape[1] // 2
+_, center_sky = mg_ii.basic_wcs.array_index_to_world(step_index, slit_index, 0)
+wcs_loc = mg_ii.basic_wcs.world_to_pixel(
     SpectralCoord(279.63, unit=u.nm),
-    SkyCoord(0 * u.arcsec, 0 * u.arcsec, frame=iris_frame),
+    center_sky,
 )
 mg_index = int(np.round(wcs_loc[0]))
 print(mg_index)
 
 ###############################################################################
-# Now we will plot spectroheliogram for Mg II k core wavelength.
-# We can use the ``crop`` method to get this information, this will
-# require a `astropy.coordinates.SpectralCoord` object from `astropy.coordinates`.
-
-# None, means that the axis is not cropped
-# Note that this has to be in axis order
-lower_corner = [SpectralCoord(280, unit=u.nm), None]
-upper_corner = [SpectralCoord(280, unit=u.nm), None]
+# Now we will plot a spectroheliogram for the Mg II k core wavelength.
+# As the raster uses a 4D gWCS, we need to provide the full world-object order
+# ``(spectral, sky, time, scan_step)``. Here we only constrain wavelength.
+lower_corner = [SpectralCoord(280, unit=u.nm), None, None, None]
+upper_corner = [SpectralCoord(280, unit=u.nm), None, None, None]
 mg_spec_crop = mg_ii.crop(lower_corner, upper_corner)
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection=mg_spec_crop.wcs)
-mg_spec_crop.plot(axes=ax)
+ax = fig.add_subplot(111, projection=mg_spec_crop.basic_wcs)
+ax.imshow(mg_spec_crop.data, origin="lower", aspect="auto")
+ax.coords[0].set_format_unit(u.arcsec)
+ax.coords[0].set_axislabel("Helioprojective Latitude [arcsec]")
+ax.coords[1].set_format_unit(u.arcsec)
+ax.coords[1].set_axislabel("Helioprojective Longitude [arcsec]")
 
 ###############################################################################
+# Plotting against ``basic_wcs`` shows the sky coordinates directly.
+# If you want to view the raster scan as time versus slit position instead,
+# plot against the full gWCS via ``mg_spec_crop.plot(...)``.
+#
+#
 # Imagine there's a really cool feature at (-338", 275"), how can you plot
-# the spectrum at that location?
+# the spectrum at that location? First locate the nearest raster pixel, then
+# convert that pixel back into the full world tuples expected by ``crop``.
 
-lower_corner = [None, SkyCoord(-338 * u.arcsec, 275 * u.arcsec, frame=iris_frame)]
-upper_corner = [None, SkyCoord(-338 * u.arcsec, 275 * u.arcsec, frame=iris_frame)]
+target = SkyCoord(-338 * u.arcsec, 275 * u.arcsec, frame=iris_frame)
+lon = mg_ii.axis_world_coords_values("custom:pos.helioprojective.lon")[0].to_value(u.arcsec)
+lat = mg_ii.axis_world_coords_values("custom:pos.helioprojective.lat")[0].to_value(u.arcsec)
+distance = (lon - target.Tx.to_value(u.arcsec)) ** 2 + (lat - target.Ty.to_value(u.arcsec)) ** 2
+step_index, slit_index = np.unravel_index(np.nanargmin(distance), distance.shape)
+lower_corner = mg_ii.wcs.array_index_to_world(step_index, slit_index, 0)
+upper_corner = mg_ii.wcs.array_index_to_world(step_index, slit_index, mg_ii.data.shape[-1] - 1)
 mg_ii_cut = mg_ii.crop(lower_corner, upper_corner)
 
 fig = plt.figure()

--- a/examples/analysis/01_spectral_fitting.py
+++ b/examples/analysis/01_spectral_fitting.py
@@ -16,13 +16,10 @@ import pooch
 
 import astropy.units as u
 from astropy import constants
-from astropy.coordinates import SkyCoord, SpectralCoord
+from astropy.coordinates import SpectralCoord
 from astropy.modeling import models as m
 from astropy.modeling.fitting import LMLSQFitter, TRFLSQFitter, parallel_fit_dask
 from astropy.visualization import time_support
-from astropy.wcs.utils import wcs_to_celestial_frame
-
-from sunpy.coordinates.frames import Helioprojective
 
 from irispy.io import read_files
 
@@ -63,18 +60,17 @@ raster = read_files(raster_filename, memmap=False)
 si_iv_1403 = raster["Si IV 1403"][0]
 
 # However, before we get to that, we will shrink the data cube to make it easier to work with.
-iris_observer = wcs_to_celestial_frame(si_iv_1403.wcs.celestial).observer
-iris_frame = Helioprojective(observer=iris_observer)
-top_left = [None, SkyCoord(-290 * u.arcsec, 260 * u.arcsec, frame=iris_frame)]
-bottom_right = [None, SkyCoord(-360 * u.arcsec, 310 * u.arcsec, frame=iris_frame)]
+n_steps, n_slit, n_lambda = si_iv_1403.data.shape
+top_left = si_iv_1403.wcs.array_index_to_world(n_steps // 4, n_slit // 4, 0)
+bottom_right = si_iv_1403.wcs.array_index_to_world(3 * n_steps // 4, 3 * n_slit // 4, n_lambda - 1)
 si_iv_1403 = si_iv_1403.crop(top_left, bottom_right)
 
 ###############################################################################
 # Let us just check the full field of view at the line core.
 
 si_iv_core = 140.277 * u.nm
-lower_corner = [SpectralCoord(si_iv_core), None]
-upper_corner = [SpectralCoord(si_iv_core), None]
+lower_corner = [SpectralCoord(si_iv_core), None, None, None]
+upper_corner = [SpectralCoord(si_iv_core), None, None, None]
 si_iv_spec_crop = si_iv_1403.crop(lower_corner, upper_corner)
 
 fig = plt.figure()

--- a/examples/analysis/02_mg_ii_dopplergrams.py
+++ b/examples/analysis/02_mg_ii_dopplergrams.py
@@ -70,8 +70,8 @@ plt.xlabel("Wavelength (nm)")
 # For this dataset, the line core of this line falls around index 350.
 # Here though, we will crop in wavelength space.
 
-lower_corner = [SpectralCoord(280.2, unit=u.nm), None]
-upper_corner = [SpectralCoord(280.2, unit=u.nm), None]
+lower_corner = [SpectralCoord(280.2, unit=u.nm), None, None, None]
+upper_corner = [SpectralCoord(280.2, unit=u.nm), None, None, None]
 mg_crop = mg_ii.crop(lower_corner, upper_corner)
 # We will "crunch" the image a bit
 mg_crop.plot(aspect="auto")

--- a/examples/analysis/03_umbral_flashes.py
+++ b/examples/analysis/03_umbral_flashes.py
@@ -55,8 +55,8 @@ mg_ii = raster["Mg II k 2796"][0]
 c_ii = raster["C II 1336"][0]
 
 # Instead of using a pixel index, we can crop the data in wavelength space.
-lower_corner = [SpectralCoord(279.63, unit=u.nm), None]
-upper_corner = [SpectralCoord(279.63, unit=u.nm), None]
+lower_corner = [SpectralCoord(279.63, unit=u.nm), None, None, None]
+upper_corner = [SpectralCoord(279.63, unit=u.nm), None, None, None]
 mg_crop = mg_ii.crop(lower_corner, upper_corner)
 
 fig = plt.figure()

--- a/examples/misc/00_v34_rasters.py
+++ b/examples/misc/00_v34_rasters.py
@@ -10,6 +10,7 @@ These v34 are scans which raster from west to east instead of the default east t
 """
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pooch
 
 import astropy.units as u
@@ -60,10 +61,9 @@ print(mg_ii_k)
 # We can use the ``crop`` method to get this information, this will
 # require a `astropy.coordinates.SpectralCoord` object from `astropy.coordinates`.
 
-# None, means that the axis is not cropped
-# Since we want one physical coordinate, we will just use the
-# same spectral coordinate for both axes.
-lower_corner = [SpectralCoord(280, unit=u.nm), None]
+# Raster gWCS crops use the full world-object order
+# ``(spectral, sky, time, scan_step)``. Here we only constrain wavelength.
+lower_corner = [SpectralCoord(280, unit=u.nm), None, None, None]
 
 mg_spec_crop = mg_ii_k[0].crop(lower_corner, lower_corner)
 mg_spec_unflipped_crop = mg_ii_k_unflipped[0].crop(lower_corner, lower_corner)
@@ -94,12 +94,18 @@ print(f"Unflipped time: {mg_ii_k_unflipped.time[:5]}")
 # We choose a specific helioprojective location and crop the spectrogram down to the
 # spectrum at that point.
 
-iris_observer = wcs_to_celestial_frame(mg_ii_k[0].wcs.celestial).observer
+iris_observer = wcs_to_celestial_frame(mg_ii_k[0].basic_wcs.celestial).observer
 iris_frame = Helioprojective(observer=iris_observer)
-lower_corner = [None, SkyCoord(-908 * u.arcsec, 311 * u.arcsec, frame=iris_frame)]
+target = SkyCoord(-908 * u.arcsec, 311 * u.arcsec, frame=iris_frame)
+lon = mg_ii_k[0].axis_world_coords_values("custom:pos.helioprojective.lon")[0].to_value(u.arcsec)
+lat = mg_ii_k[0].axis_world_coords_values("custom:pos.helioprojective.lat")[0].to_value(u.arcsec)
+distance = (lon - target.Tx.to_value(u.arcsec)) ** 2 + (lat - target.Ty.to_value(u.arcsec)) ** 2
+step_index, slit_index = np.unravel_index(np.nanargmin(distance), distance.shape)
+lower_corner = mg_ii_k[0].wcs.array_index_to_world(step_index, slit_index, 0)
+upper_corner = mg_ii_k[0].wcs.array_index_to_world(step_index, slit_index, mg_ii_k[0].data.shape[-1] - 1)
 
-mg_ii_k_unflipped_spectra = mg_ii_k_unflipped[0].crop(lower_corner, lower_corner)
-mg_ii_k_spectra = mg_ii_k[0].crop(lower_corner, lower_corner)
+mg_ii_k_unflipped_spectra = mg_ii_k_unflipped[0].crop(lower_corner, upper_corner)
+mg_ii_k_spectra = mg_ii_k[0].crop(lower_corner, upper_corner)
 
 fig = plt.figure()
 ax = fig.add_subplot(111, projection=mg_ii_k_unflipped_spectra.wcs)

--- a/irispy/data/test/get_cali_test_data.pro
+++ b/irispy/data/test/get_cali_test_data.pro
@@ -6,7 +6,6 @@ read_iris_l2, raster_filename, index, data
 input_spectrum = reform(data[11, 20, *])
 wavelength = indgen(187) * 0.025960000231900000 + 1332.6762501600001
 save, input_spectrum, wavelength, filename = 'input_calibration.sav'
-; You need to modify the below return to save the outputs we need:
-; Add save, outputspectrum, factor, filename = 'output_calibration.sav' before the return
-IRIS_CALIB_SPECTRUM(input_spectrum, wavelength, /verbose)
+outputspectrum, factor = IRIS_CALIB_SPECTRUM(input_spectrum, wavelength, /verbose)
+save, outputspectrum, factor, filename = 'output_calibration.sav'
 end

--- a/irispy/io/spectrograph.py
+++ b/irispy/io/spectrograph.py
@@ -1,19 +1,24 @@
+import warnings
 from copy import copy
 from pathlib import Path
 
 import numpy as np
 
+import astropy.modeling.models as m
 import astropy.units as u
+import gwcs
+import gwcs.coordinate_frames as cf
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.time import Time, TimeDelta
 from astropy.wcs import WCS
 
-from sunpy import log as logger
+from dkist.wcs.models import AsymmetricMapping, CoupledCompoundModel, VaryingCelestialTransform
 from sunpy.coordinates.ephemeris import get_body_heliographic_stonyhurst
 from sunpy.coordinates.frames import HeliographicStonyhurst, Helioprojective
 from sunpy.coordinates.screens import SphericalScreen
 from sunpy.coordinates.wcs_utils import _set_wcs_aux_obs_coord
+from sunpy.time import parse_time
 
 from irispy.meta import SGMeta
 from irispy.spectrograph import RasterCollection, SpectrogramCube, SpectrogramCubeSequence
@@ -25,6 +30,208 @@ __all__ = ["read_spectrograph_lvl2"]
 
 def _pc_matrix(lam, angle_1, angle_2):
     return angle_1, -1 * lam * angle_2, 1 / lam * angle_2, angle_1
+
+
+def _header_time(header, *keys):
+    for key in keys:
+        value = header.get(key)
+        if value:
+            return Time(value, format="isot", scale="utc")
+    msg = f"Header is missing all usable time keys: {keys}"
+    raise ValueError(msg)
+
+
+def _make_observer(primary_header):
+    base_time = _header_time(primary_header, "DATE_OBS", "STARTOBS")
+    location = get_body_heliographic_stonyhurst("Earth", base_time.isot)
+    observer = Helioprojective(
+        primary_header["XCEN"] * u.arcsec,
+        primary_header["YCEN"] * u.arcsec,
+        observer=location,
+        obstime=base_time,
+    )
+    with SphericalScreen(observer.observer):
+        return observer.transform_to(HeliographicStonyhurst(obstime=base_time))
+
+
+def _raster_wcs_bad_row_mask(pc, crval):
+    """Return AUX rows whose PC or CRVAL table entries are unusable."""
+    pc_bad = np.array([np.allclose(pc[i], 0) for i in range(pc.shape[0])])
+    crval_bad = np.array([np.allclose(crval[i], 0) for i in range(crval.shape[0])])
+    return pc_bad | crval_bad
+
+
+def _sanitize_raster_wcs_tables(pc, crval, fallback_pc=None, fallback_crval=None):
+    """Replace all-zero PC/crval rows via neighbour interpolation or fallback."""
+    bad_rows = _raster_wcs_bad_row_mask(pc, crval)
+    if not bad_rows.any():
+        return pc, crval
+
+    n_bad = int(bad_rows.sum())
+    warnings.warn(
+        f"Found {n_bad} step(s) with all-zero WCS tables in raster aux data. "
+        "Interpolating from neighbouring steps.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+    good_indices = np.nonzero(~bad_rows)[0]
+    if good_indices.size == 0:
+        if fallback_pc is None or fallback_crval is None:
+            msg = "All WCS table rows are bad and no fallback values are available."
+            raise ValueError(msg)
+        warnings.warn(
+            "All steps in this file have bad WCS tables. Using fallback values from observation mean.",
+            UserWarning,
+            stacklevel=3,
+        )
+        for i in range(pc.shape[0]):
+            pc[i] = fallback_pc
+            crval[i] = fallback_crval
+        return pc, crval
+
+    for i in np.where(bad_rows)[0]:
+        before = good_indices[good_indices < i]
+        after = good_indices[good_indices > i]
+        if before.size > 0 and after.size > 0:
+            b = before[-1]
+            a = after[0]
+            weight = (i - b) / (a - b)
+            pc[i] = pc[b] * (1 - weight) + pc[a] * weight
+            crval[i] = crval[b] * (1 - weight) + crval[a] * weight
+        elif before.size > 0:
+            pc[i] = pc[before[-1]]
+            crval[i] = crval[before[-1]]
+        elif after.size > 0:
+            pc[i] = pc[after[0]]
+            crval[i] = crval[after[0]]
+    return pc, crval
+
+
+def _prepare_raster_wcs_header(header, aux_data, spectral_band, *, flip):
+    header = copy(header)
+    if header.get("CUNIT1", "").lower() == "angstrom":
+        header["CUNIT1"] = "nm"
+        header["CRVAL1"] *= 0.1
+        header["CDELT1"] *= 0.1
+    offset_index = 34 if spectral_band == "FUV" else 45
+    header["CRVAL3"] -= aux_data[:, offset_index].mean() * (SLIT_WIDTH.value / 2)
+    if header["CDELT3"] == 0:
+        header["CDELT3"] = 1e-10
+        ang1, ang2, ang3, ang4 = _pc_matrix(
+            header["CDELT3"] / header["CDELT2"],
+            aux_data[:, 20].mean(),
+            aux_data[:, 22].mean(),
+        )
+        header["PC2_2"] = ang1
+        header["PC2_3"] = ang2
+        header["PC3_2"] = ang3
+        header["PC3_3"] = ang4
+    if flip:
+        header["PC1_3"] = 0
+        header["PC2_3"] = -header["PC2_3"]
+        header["PC3_2"] = -header["PC3_2"]
+        header["CDELT3"] = -header["CDELT3"]
+        header["CRPIX3"] = header["NAXIS3"] - header["CRPIX3"] + 1
+    return header
+
+
+def _create_basic_raster_wcs(header, observer):
+    wcs = WCS(header)
+    _set_wcs_aux_obs_coord(wcs, observer)
+    return wcs
+
+
+def _create_raster_gwcs(window_header, pc_all, crval_all, dt_all, t_ref, observer):
+    """
+    Build the raster gWCS from per-step AUX sky and timing tables.
+
+    The spectral axis stays a 1D linear transform. The scan axis expands into
+    helioprojective sky coordinates, elapsed time from ``t_ref``, and an
+    explicit scan-step coordinate so the inverse stays stable for crops and
+    other round-trips where sky or time alone are not unique.
+    """
+    if window_header.get("CUNIT1", "").lower() == "angstrom":
+        cdelt1 = window_header["CDELT1"] * 0.1
+        crval1 = window_header["CRVAL1"] * 0.1
+    else:
+        cdelt1 = window_header["CDELT1"]
+        crval1 = window_header["CRVAL1"]
+    crpix1 = window_header.get("CRPIX1", 1.0)
+    spectral = m.Linear1D(
+        slope=cdelt1 * u.nm / u.pix,
+        intercept=(crval1 - cdelt1 * (crpix1 - 1)) * u.nm,
+        name="Wavelength",
+    )
+
+    crpix_table = np.array([window_header["CRPIX2"], window_header["CRPIX3"]]) * u.pix
+    cdelt = np.array([window_header["CDELT2"], window_header["CDELT3"]]) * (u.arcsec / u.pix)
+    celestial_raw = VaryingCelestialTransform(
+        cdelt=cdelt,
+        pc_table=pc_all,
+        crval_table=crval_all,
+        crpix_table=crpix_table,
+    )
+    if np.isclose(window_header["CDELT3"], 1e-10):
+        celestial = celestial_raw
+    else:
+        celestial = celestial_raw | m.Mapping((1, 0), name="SwapHelioprojectiveAxes")
+        celestial.inverse = m.Mapping((1, 0, 2), n_inputs=3, name="SwapHelioprojectiveAxesInverseInputs") | (
+            celestial_raw.inverse
+        )
+
+    temporal = m.Tabular1D(
+        np.arange(pc_all.shape[0]) * u.pix,
+        lookup_table=dt_all,
+        fill_value=np.nan,
+        bounds_error=False,
+        method="linear",
+        name="Time",
+    )
+    slit_step_mapping = AsymmetricMapping([0, 1, 1, 1], [0, 1], name="SlitStepMapping")
+    non_spectral_rhs = CoupledCompoundModel("&", left=celestial, right=temporal, shared_inputs=1) & m.Identity(
+        1, name="step"
+    )
+    non_spectral = slit_step_mapping | non_spectral_rhs
+    non_spectral.inverse = non_spectral_rhs.inverse | m.Mapping(
+        (0, 3),
+        n_inputs=4,
+        name="SelectSlitAndExplicitStep",
+    )
+    forward_transform = spectral & non_spectral
+    forward_transform.inverse = spectral.inverse & non_spectral.inverse
+
+    base_time = parse_time(t_ref)
+    spectral_frame = cf.SpectralFrame(axes_order=(0,), unit=u.nm, name="wavelength", axes_names=("wavelength",))
+    celestial_frame = cf.CelestialFrame(
+        axes_order=(1, 2),
+        unit=(u.arcsec, u.arcsec),
+        reference_frame=Helioprojective(observer=observer, obstime=observer.obstime),
+        axis_physical_types=["custom:pos.helioprojective.lon", "custom:pos.helioprojective.lat"],
+        axes_names=("helioprojective longitude", "helioprojective latitude"),
+    )
+    temporal_frame = cf.TemporalFrame(base_time, unit=(u.s,), axes_order=(3,), axes_names=("Seconds from Start (s)",))
+    step_frame = cf.CoordinateFrame(
+        naxes=1,
+        axes_order=(4,),
+        axes_names=("scan_step",),
+        axes_type=("STEP",),
+        unit=(u.pix,),
+        name="step",
+    )
+    output_frame = cf.CompositeFrame([spectral_frame, celestial_frame, temporal_frame, step_frame])
+    pixel_frame = cf.CoordinateFrame(
+        naxes=3,
+        axes_order=(0, 1, 2),
+        axes_names=["dispersion axis", "spatial along slit", "scan/step number"],
+        axes_type=["PIXEL", "PIXEL", "PIXEL"],
+        unit=(u.pix, u.pix, u.pix),
+    )
+    return gwcs.WCS(
+        forward_transform,
+        input_frame=pixel_frame,
+        output_frame=output_frame,
+    )
 
 
 def read_spectrograph_lvl2(
@@ -67,17 +274,13 @@ def read_spectrograph_lvl2(
     if isinstance(filenames, (str, Path)):
         filenames = [filenames]
     filenames = [str(f) for f in filenames]
-    # Collecting the window observations
     with fits.open(filenames[0], memmap=memmap, do_not_scale_image_data=memmap) as hdulist:
-        # After a discussion with the IRIS team, it was decided that instead of the
-        # OBSID, we will use STEPS_AV less than -0.01 to identify V34 observations.
         v34 = hdulist[0].header["STEPS_AV"] < -0.01
         hdulist.verify("silentfix")
+        primary_header = hdulist[0].header.copy()
         windows_in_obs = np.array(
-            [hdulist[0].header[f"TDESC{i}"] for i in range(1, hdulist[0].header["NWIN"] + 1)],
+            [primary_header[f"TDESC{i}"] for i in range(1, primary_header["NWIN"] + 1)],
         )
-        # If spectral_window is not set then get every window.
-        # Else take the appropriate windows
         if not spectral_windows:
             spectral_windows_req = windows_in_obs
             window_fits_indices = range(1, len(hdulist) - 2)
@@ -86,41 +289,50 @@ def read_spectrograph_lvl2(
             spectral_windows_req = np.asarray(spectral_windows_req, dtype="U")
             window_is_in_obs = np.asarray([window in windows_in_obs for window in spectral_windows_req])
             if not all(window_is_in_obs):
-                missing_windows = window_is_in_obs is False
-                msg = f"Spectral windows {spectral_windows[missing_windows]} not in file {filenames[0]}"
+                missing_windows = spectral_windows_req[~window_is_in_obs]
+                msg = f"Spectral windows {missing_windows.tolist()} not in file {filenames[0]}"
                 raise ValueError(msg)
             window_fits_indices = np.nonzero(np.isin(windows_in_obs, spectral_windows))[0] + 1
         data_dict = {window_name: [] for window_name in spectral_windows_req}
-        # No observer information in the header, so we just assume its at Earth.
-        base_time = Time(hdulist[0].header["DATE_OBS"])
-        location = get_body_heliographic_stonyhurst("Earth", (base_time).isot)
-        observer = Helioprojective(
-            hdulist[0].header["XCEN"] * u.arcsec,
-            hdulist[0].header["YCEN"] * u.arcsec,
-            observer=location,
-            obstime=base_time,
-        )
-        with SphericalScreen(observer.observer):
-            observer = observer.transform_to(HeliographicStonyhurst(obstime=base_time))
+        observer = _make_observer(primary_header)
+
+    # Running mean of good WCS table rows across files (used as fallback).
+    running_pc_sum = np.zeros((2, 2))
+    running_crval_sum = np.zeros(2)
+    running_count = 0
+
     for filename in filenames:
         with fits.open(filename, memmap=memmap, do_not_scale_image_data=memmap) as hdulist:
             hdulist.verify("silentfix")
-            # Extract axis-aligned metadata.
-            times = Time(hdulist[0].header["STARTOBS"]) + TimeDelta(
-                hdulist[-2].data[:, hdulist[-2].header["TIME"]],
-                format="sec",
-            )
+            aux = hdulist[-2]
+            file_startobs = _header_time(hdulist[0].header, "STARTOBS", "DATE_OBS")
+            times = file_startobs + TimeDelta(aux.data[:, aux.header["TIME"]] * u.s)
             fov_center = SkyCoord(
-                Tx=hdulist[-2].data[:, hdulist[-2].header["XCENIX"]],
-                Ty=hdulist[-2].data[:, hdulist[-2].header["YCENIX"]],
+                Tx=aux.data[:, aux.header["XCENIX"]],
+                Ty=aux.data[:, aux.header["YCENIX"]],
                 unit=u.arcsec,
                 frame=Helioprojective,
             )
-            obs_vrix = hdulist[-2].data[:, hdulist[-2].header["OBS_VRIX"]] * u.m / u.s
-            ophaseix = hdulist[-2].data[:, hdulist[-2].header["OPHASEIX"]]
-            exposure_times_fuv = hdulist[-2].data[:, hdulist[-2].header["EXPTIMEF"]] * u.s
-            exposure_times_nuv = hdulist[-2].data[:, hdulist[-2].header["EXPTIMEN"]] * u.s
+            obs_vrix = aux.data[:, aux.header["OBS_VRIX"]] * u.m / u.s
+            ophaseix = aux.data[:, aux.header["OPHASEIX"]]
+            exposure_times_fuv = aux.data[:, aux.header["EXPTIMEF"]] * u.s
+            exposure_times_nuv = aux.data[:, aux.header["EXPTIMEN"]] * u.s
+            pc_indices = [aux.header[key] for key in ("PC2_2IX", "PC2_3IX", "PC3_2IX", "PC3_3IX")]
+            pc = aux.data[:, pc_indices].reshape(-1, 2, 2) * u.pix
+
+            flip = v34 and not revert_v34
+            if flip:
+                times = times[::-1]
+                obs_vrix = obs_vrix[::-1]
+                ophaseix = ophaseix[::-1]
+                exposure_times_fuv = exposure_times_fuv[::-1]
+                exposure_times_nuv = exposure_times_nuv[::-1]
+                pc = pc[::-1]
+            t_ref = times[0]
+            dt = (times - t_ref).to_value(u.s) * u.s
+
             for i, window_name in enumerate(spectral_windows_req):
+                window_header = hdulist[window_fits_indices[i]].header.copy()
                 meta = SGMeta(
                     hdulist[0].header,
                     window_name,
@@ -137,33 +349,49 @@ def read_spectrograph_lvl2(
                 meta.add("exposure FOV center", fov_center, None, 0)
                 meta.add("observer radial velocity", obs_vrix, None, 0)
                 meta.add("orbital phase", ophaseix, None, 0)
-                # Sit-and-stare have a CDELT of 0 which causes issues in WCS.
-                # In this case, set CDELT to a small number.
-                header = copy(hdulist[window_fits_indices[i]].header)
-                # Account for a slit offset (POFFYNUV (45) or POFFYFUV (34))
-                idx = 34 if meta.spectral_band == "FUV" else 45
-                header["CRVAL3"] -= hdulist[-2].data[:, idx].mean() * (SLIT_WIDTH.value / 2)
-                if header["CDELT3"] == 0:
-                    header["CDELT3"] = 1e-10
-                    ang1, ang2, ang3, ang4 = _pc_matrix(
-                        header["CDELT3"] / header["CDELT2"],
-                        hdulist[-2].data[:, 20].mean(),
-                        hdulist[-2].data[:, 22].mean(),
+                prepared_wcs_header = _prepare_raster_wcs_header(
+                    window_header,
+                    aux.data,
+                    meta.spectral_band,
+                    flip=flip,
+                )
+                if np.isclose(window_header["CDELT3"], 0):
+                    # Sit-and-stare: CRVAL comes from the header, only PC may need fallback.
+                    crval = (
+                        np.repeat(
+                            [[prepared_wcs_header["CRVAL3"], prepared_wcs_header["CRVAL2"]]],
+                            len(times),
+                            axis=0,
+                        )
+                        * u.arcsec
                     )
-                    header["PC2_2"] = ang1
-                    header["PC2_3"] = ang2
-                    header["PC3_2"] = ang3
-                    header["PC3_3"] = ang4
-                try:
-                    wcs = WCS(header)
-                except Exception as e:  # NOQA: BLE001
-                    msg = (
-                        f"WCS failed to load while reading one step of the raster due to {e}"
-                        "The loading will continue but this will be missing in the final cube. "
-                        f"Spectral window: {window_name}, step {i} in file: {filename}"
-                    )
-                    logger.warning(msg)
-                    continue
+                else:
+                    offset_index = 34 if meta.spectral_band == "FUV" else 45
+                    xcen = aux.data[:, aux.header["XCENIX"]] - aux.data[:, offset_index] * (SLIT_WIDTH.value / 2)
+                    ycen = aux.data[:, aux.header["YCENIX"]]
+                    crval = np.column_stack((ycen, xcen)) * u.arcsec
+                    if flip:
+                        crval = crval[::-1]
+
+                # Update running mean from good rows in the first window of each file.
+                if i == 0:
+                    good_mask = ~_raster_wcs_bad_row_mask(pc, crval)
+                    if good_mask.any():
+                        running_pc_sum += pc[good_mask].sum(axis=0).to_value(u.pix)
+                        running_crval_sum += crval[good_mask].sum(axis=0).to_value(u.arcsec)
+                        running_count += good_mask.sum()
+
+                fallback_pc = (
+                    (running_pc_sum / running_count * u.pix)
+                    if running_count > 0 else None
+                )
+                fallback_crval = (
+                    (running_crval_sum / running_count * u.arcsec)
+                    if running_count > 0 else None
+                )
+                pc_sanitized, crval = _sanitize_raster_wcs_tables(pc.copy(), crval, fallback_pc, fallback_crval)
+                basic_wcs = _create_basic_raster_wcs(prepared_wcs_header, observer)
+
                 out_uncertainty = None
                 data_mask = None
                 if not memmap:
@@ -174,30 +402,30 @@ def read_spectrograph_lvl2(
                         readout_noise,
                         dn_unit,
                     )
-                if v34 and not revert_v34:
-                    times = times[::-1]
+                if flip:
                     data = np.flip(hdulist[window_fits_indices[i]].data, axis=0)
-                    header["PC1_3"] = 0
-                    header["PC2_3"] = -header["PC2_3"]
-                    header["PC3_2"] = -header["PC3_2"]
-                    header["CDELT3"] = -header["CDELT3"]
-                    header["CRPIX3"] = header["NAXIS3"] - header["CRPIX3"] + 1
-                    wcs = WCS(header)
                 else:
                     data = hdulist[window_fits_indices[i]].data
-                _set_wcs_aux_obs_coord(wcs, observer)
                 cube = SpectrogramCube(
                     data,
-                    wcs=wcs,
+                    wcs=_create_raster_gwcs(
+                        prepared_wcs_header,
+                        pc_sanitized,
+                        crval,
+                        dt,
+                        t_ref,
+                        observer,
+                    ),
                     uncertainty=out_uncertainty,
                     unit=dn_unit,
                     meta=meta,
                     mask=data_mask,
+                    _basic_wcs=basic_wcs,
                 )
                 cube.extra_coords.add("time", 0, times, physical_types="time")
                 data_dict[window_name].append(cube)
     window_data_pairs = [
-        (window_name, SpectrogramCubeSequence(data_dict[window_name], common_axis=0, meta=hdulist[0].header))
+        (window_name, SpectrogramCubeSequence(data_dict[window_name], common_axis=0, meta=primary_header))
         for window_name in spectral_windows_req
     ]
     return RasterCollection(window_data_pairs, aligned_axes=(0, 1, 2))

--- a/irispy/io/tests/test_spectrograph.py
+++ b/irispy/io/tests/test_spectrograph.py
@@ -1,12 +1,18 @@
+import warnings
+
 import numpy as np
+import pytest
 
 import astropy.units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.units.errors import UnitsWarning
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.wcs.utils import wcs_to_celestial_frame
 
 from sunpy.coordinates import Helioprojective
 
-from irispy.io.spectrograph import read_spectrograph_lvl2
+from irispy.io.spectrograph import _raster_wcs_bad_row_mask, read_spectrograph_lvl2
 
 
 def test_sns_read_spectrograph_lvl2(sns_sg_file):
@@ -80,6 +86,9 @@ def test_sns_read_spectrograph_lvl2(sns_sg_file):
     assert meta.observer_location is None
     assert meta.rsun_angular is None
     assert meta.rsun_meters is None
+    assert si_iv[0].wcs.world_n_dim == 5
+    assert si_iv[0].wcs.pixel_n_dim == 3
+    assert si_iv[0].basic_wcs is not None
 
 
 def test_raster_all_files_read_spectrograph_lvl2(raster_sg_files):
@@ -154,9 +163,133 @@ def test_raster_all_files_read_spectrograph_lvl2(raster_sg_files):
     assert meta.observer_location is None
     assert meta.rsun_angular is None
     assert meta.rsun_meters is None
+    assert si_iv[0].wcs.world_n_dim == 5
+    assert si_iv[0].wcs.pixel_n_dim == 3
+    assert si_iv.time.format == "isot"
 
 
 def test_smoke_read_spectrograph_lvl2(sns_sg_file, raster_sg_file, raster_sg_files):
     read_spectrograph_lvl2(sns_sg_file)
     read_spectrograph_lvl2(raster_sg_file)
     read_spectrograph_lvl2(raster_sg_files)
+
+
+def test_raster_wcs_bad_row_mask_rejects_partial_zero_rows():
+    pc = np.array(
+        [
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[0.0, 0.0], [0.0, 0.0]],
+            [[1.0, 0.0], [0.0, 1.0]],
+        ]
+    ) * u.pix
+    crval = np.array(
+        [
+            [10.0, 20.0],
+            [10.0, 20.0],
+            [0.0, 0.0],
+        ]
+    ) * u.arcsec
+
+    assert np.array_equal(_raster_wcs_bad_row_mask(pc, crval), np.array([False, True, True]))
+
+
+def test_read_spectrograph_lvl2_reports_all_missing_spectral_windows(raster_sg_file):
+    with pytest.raises(ValueError, match=r"Spectral windows .* not in file") as excinfo:
+        read_spectrograph_lvl2(raster_sg_file, spectral_windows=["NOPE1", "NOPE2"])
+
+    message = str(excinfo.value)
+    assert "NOPE1" in message
+    assert "NOPE2" in message
+
+
+def test_gwcs_crop_supports_full_world_component_api(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files)
+    scan = raster_collection["Si IV 1403"][0]
+
+    spectral_coord = scan.spectral_axis[len(scan.spectral_axis) // 2]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        spectral_crop = scan.crop(
+            [SpectralCoord(spectral_coord), None, None, None],
+            [SpectralCoord(spectral_coord), None, None, None],
+        )
+    assert spectral_crop.data.ndim == 2
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        spectrum = scan.crop(
+            scan.wcs.array_index_to_world(3, 50, 0),
+            scan.wcs.array_index_to_world(3, 50, scan.data.shape[-1] - 1),
+        )
+    assert spectrum.data.ndim == 1
+
+
+def test_gwcs_crop_rejects_removed_two_component_shorthand(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files)
+    scan = raster_collection["Si IV 1403"][0]
+    spectral_coord = scan.spectral_axis[len(scan.spectral_axis) // 2]
+    frame = wcs_to_celestial_frame(scan.basic_wcs.celestial)
+    target = SkyCoord(-8 * u.arcsec, 370 * u.arcsec, unit=u.arcsec, frame=frame)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        with pytest.raises(ValueError, match="do not match WCS"):
+            scan.crop([SpectralCoord(spectral_coord), None], [SpectralCoord(spectral_coord), None])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        with pytest.raises(ValueError, match="do not match WCS"):
+            scan.crop([None, target], [None, target])
+
+
+def test_gwcs_inverse_enables_official_crop_api(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files)
+    scan = raster_collection["Si IV 1403"][0]
+
+    start = scan.wcs.array_index_to_world(3, 50, 10)
+    stop = scan.wcs.array_index_to_world(4, 50, 10)
+
+    assert scan.wcs.world_to_array_index(*start) == (3, 50, 10)
+    assert scan.wcs.world_to_array_index(*stop) == (4, 50, 10)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        cropped = scan.crop(start, stop)
+    assert cropped.data.shape == (2,)
+
+
+def test_gwcs_inverse_roundtrips_sit_and_stare_exposures(sns_sg_file):
+    raster_collection = read_spectrograph_lvl2(sns_sg_file)
+    scan = raster_collection["Si IV 1403"][0]
+
+    start = scan.wcs.array_index_to_world(3, 20, 10)
+    stop = scan.wcs.array_index_to_world(4, 20, 10)
+
+    assert scan.wcs.world_to_array_index(*start) == (3, 20, 10)
+    assert scan.wcs.world_to_array_index(*stop) == (4, 20, 10)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        cropped = scan.crop(start, stop)
+    assert cropped.data.shape == (2,)
+
+def test_raster_gwcs_matches_basic_wcs_forward_world_coordinates(raster_sg_files):
+    raster_collection = read_spectrograph_lvl2(raster_sg_files)
+    scan = raster_collection["Si IV 1403"][0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        for array_index in ((0, 50, 3), (3, 50, 10), (7, 80, 20)):
+            spectral, sky, _, _ = scan.wcs.array_index_to_world(*array_index)
+            basic_spectral, basic_sky = scan.basic_wcs.array_index_to_world(*array_index)
+
+            assert_quantity_allclose(spectral.to(u.nm), basic_spectral.to(u.nm))
+            assert_quantity_allclose(sky.Tx.to(u.arcsec), basic_sky.Tx.to(u.arcsec), atol=10 * u.arcsec)
+            assert_quantity_allclose(sky.Ty.to(u.arcsec), basic_sky.Ty.to(u.arcsec), atol=1 * u.arcsec)

--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -15,7 +15,7 @@ from sunraster import SpectrogramCube
 from irispy.utils import calculate_dust_mask
 from irispy.utils.cosmic_rays import remove_cosmic_rays
 from irispy.utils.dust import remove_dust as _remove_dust
-from irispy.visualization import IRISPlotter, set_axis_properties
+from irispy.visualization import IRISPlotter, finalize_iris_plot
 
 __all__ = ["AIACube", "SJICube"]
 
@@ -173,9 +173,7 @@ class SJICube(SpectrogramCube):
                 logger.debug(e)
                 cmap = "viridis"
         kwargs["cmap"] = cmap
-        ax = IRISPlotter(ndcube=self).plot(*args, **kwargs)
-        set_axis_properties(ax)
-        return ax
+        return finalize_iris_plot(IRISPlotter(ndcube=self).plot(*args, **kwargs), kwargs.get("axes_coordinates"))
 
     def apply_dust_mask(self, *, undo=False):
         """

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -1,4 +1,5 @@
 import textwrap
+from numbers import Integral
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -9,9 +10,35 @@ from sunraster import SpectrogramCube as SpecCube
 from sunraster import SpectrogramSequence as SpecSeq
 
 from irispy.utils.cosmic_rays import remove_cosmic_rays
-from irispy.visualization import IRISPlotter, IRISSequencePlotter, set_axis_properties
+from irispy.visualization import IRISPlotter, IRISSequencePlotter, finalize_iris_plot
 
 __all__ = ["RasterCollection", "SpectrogramCube", "SpectrogramCubeSequence"]
+
+
+def _normalize_tuple_index(item, ndim):
+    """
+    Normalize a tuple index to explicit per-axis entries.
+
+    Returns
+    -------
+    list or None
+        A normalized list of length ``ndim`` when normalization is valid.
+        Returns ``None`` when the tuple contains more than one ellipsis.
+    """
+    normalized_item = []
+    ellipsis_seen = False
+    for subitem in item:
+        if subitem is Ellipsis:
+            if ellipsis_seen:
+                return None
+            ellipsis_seen = True
+            missing_dims = ndim - (len(item) - 1)
+            normalized_item.extend([slice(None)] * missing_dims)
+        else:
+            normalized_item.append(subitem)
+    if len(normalized_item) < ndim:
+        normalized_item.extend([slice(None)] * (ndim - len(normalized_item)))
+    return normalized_item
 
 
 class SpectrogramCube(SpecCube):
@@ -53,18 +80,37 @@ class SpectrogramCube(SpecCube):
     """
 
     def __init__(self, data, wcs, uncertainty, unit, meta, *, mask=None, copy=False, **kwargs) -> None:
+        self._basic_wcs = kwargs.pop("_basic_wcs", None)
         super().__init__(data, wcs, unit=unit, uncertainty=uncertainty, mask=mask, meta=meta, copy=copy, **kwargs)
 
+    @property
+    def time(self):
+        time = super().time
+        if time.format == "jd":
+            time = time.copy()
+            time.format = "isot"
+        return time
+
+    def _slice_basic_wcs(self, item):
+        if self._basic_wcs is None:
+            return None
+        if isinstance(item, tuple):
+            item = _normalize_tuple_index(item, self.data.ndim)
+            if item is None or not all(isinstance(subitem, (Integral, slice)) for subitem in item):
+                return None
+            item = tuple(item)
+        elif not isinstance(item, (Integral, slice)) and item is not Ellipsis:
+            return None
+        try:
+            return self._basic_wcs.slice(item, numpy_order=True)
+        except (IndexError, NotImplementedError, TypeError, ValueError) as e:
+            logger.debug(f"Unable to slice SpectrogramCube basic_wcs with item {item!r}: {e}")
+            return None
+
     def __getitem__(self, item):
-        result = super().__getitem__(item)
-        return SpectrogramCube(
-            result.data,
-            result.wcs,
-            result.uncertainty,
-            result.unit,
-            result.meta,
-            mask=result.mask,
-        )
+        sliced_self = super().__getitem__(item)
+        sliced_self._basic_wcs = self._slice_basic_wcs(item)
+        return sliced_self
 
     def __repr__(self) -> str:
         return f"{object.__repr__(self)}\n{self!s}"
@@ -75,9 +121,23 @@ class SpectrogramCube(SpecCube):
         if self.global_coords and "time" in self.global_coords:
             instance_start = self.global_coords["time"].min().isot
             instance_end = self.global_coords["time"].max().isot
-        elif self.extra_coords and self.axis_world_coords("time", wcs=self.extra_coords):
-            instance_start = self.axis_world_coords("time", wcs=self.extra_coords)[0].min().isot
-            instance_end = self.axis_world_coords("time", wcs=self.extra_coords)[0].max().isot
+        elif self.extra_coords:
+            try:
+                extra_coord_time = self.axis_world_coords("time", wcs=self.extra_coords)
+            except ValueError as e:
+                logger.debug(f"Unable to determine time bounds for SpectrogramCube string representation: {e}")
+                extra_coord_time = None
+            if extra_coord_time:
+                instance_start = extra_coord_time[0].min().isot
+                instance_end = extra_coord_time[0].max().isot
+        if instance_start is None or instance_end is None:
+            try:
+                instance_start = self.time.min().isot
+                instance_end = self.time.max().isot
+            except ValueError as e:
+                logger.debug(f"Unable to determine time bounds for SpectrogramCube string representation: {e}")
+                instance_start = "Unknown"
+                instance_end = "Unknown"
         return textwrap.dedent(
             f"""
             SpectrogramCube
@@ -102,9 +162,11 @@ class SpectrogramCube(SpecCube):
         kwargs["cmap"] = cmap
         if len(self.shape) == 1:
             kwargs.pop("cmap")
-        ax = IRISPlotter(ndcube=self).plot(*args, **kwargs)
-        set_axis_properties(ax)
-        return ax
+        return finalize_iris_plot(IRISPlotter(ndcube=self).plot(*args, **kwargs), kwargs.get("axes_coordinates"))
+
+    @property
+    def basic_wcs(self):
+        return self._basic_wcs
 
     def remove_cosmic_rays(
         self,
@@ -162,14 +224,12 @@ class SpectrogramCubeSequence(SpecSeq):
     """
 
     def __init__(self, data_list, meta=None, common_axis=0, **kwargs) -> None:
-        # Check that all spectrograms are from same spectral window and OBS ID.
-        if len(np.unique([cube.meta["OBSID"] for cube in data_list])) != 1:
+        if data_list and len(np.unique([cube.meta["OBSID"] for cube in data_list])) != 1:
             msg = "Constituent SpectrogramCube objects must have same value of 'OBSID' in its meta."
             raise ValueError(msg)
         super().__init__(data_list, meta=meta, common_axis=common_axis, **kwargs)
 
     def __str__(self) -> str:
-        # Overload it get the class name in the string
         return super().__str__()
 
     def plot(self, *args, **kwargs):
@@ -183,9 +243,31 @@ class SpectrogramCubeSequence(SpecSeq):
         kwargs["cmap"] = cmap
         if len(self.shape) == 1:
             kwargs.pop("cmap")
-        ax = IRISSequencePlotter(ndcube=self).plot(*args, **kwargs)
-        set_axis_properties(ax)
-        return ax
+        return finalize_iris_plot(
+            IRISSequencePlotter(ndcube=self).plot(*args, **kwargs),
+            kwargs.get("axes_coordinates"),
+        )
+
+    def remove_cosmic_rays(
+        self,
+        *,
+        method="rsliding",
+        sigma: float | None = None,
+        max_iters: int | None = None,
+        method_kwargs=None,
+    ):
+        """
+        Return a cleaned copy of each cube in the sequence.
+
+        This is a convenience wrapper around `irispy.utils.cosmic_rays.remove_cosmic_rays`.
+        """
+        return remove_cosmic_rays(
+            self,
+            method=method,
+            sigma=sigma,
+            max_iters=max_iters,
+            method_kwargs=method_kwargs,
+        )
 
 
 class RasterCollection(NDCollection):

--- a/irispy/tests/test_spectrograph.py
+++ b/irispy/tests/test_spectrograph.py
@@ -1,8 +1,17 @@
 import copy
+import warnings
+from types import SimpleNamespace
 
+import matplotlib.pyplot as plt
 import numpy as np
 
+import astropy.units as u
+from astropy.coordinates import SpectralCoord
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.io import fits
+from astropy.units import UnitsWarning
+from ndcube.utils.exceptions import NDCubeUserWarning
 
 from irispy.io.spectrograph import read_spectrograph_lvl2
 
@@ -61,9 +70,259 @@ def test_spectrogram_cube_remove_cosmic_rays(sns_sg_file, monkeypatch):
     assert captured["max_iters"] == 5
     assert captured["method_kwargs"]["batch_size"] == 16
     np.testing.assert_array_equal(captured["mask"], cube.mask)
-    # WCS is deep-copied, so check equivalence not identity
-    assert dict(cleaned_cube.wcs.to_header()) == dict(cube.wcs.to_header())
+    array_index = (3, 20, 10)
+    world = cube.wcs.array_index_to_world(*array_index)
+    assert cleaned_cube.wcs.world_to_array_index(*world) == array_index
     assert list(cleaned_cube.global_coords) == list(cube.global_coords)
     assert cleaned_cube.unit == cube.unit
     # meta is an NDMeta subclass that may contain arrays; compare keys only
     assert set(cleaned_cube.meta.keys()) == set(cube.meta.keys())
+
+
+def test_spectrogram_cube_sequence_remove_cosmic_rays(sns_sg_file, monkeypatch):
+    captured = {}
+
+    def fake_remove_cosmic_rays(cube, *, method, sigma, max_iters, method_kwargs):
+        captured["cube"] = cube
+        captured["method"] = method
+        captured["sigma"] = sigma
+        captured["max_iters"] = max_iters
+        captured["method_kwargs"] = method_kwargs
+        return cube
+
+    monkeypatch.setattr("irispy.spectrograph.remove_cosmic_rays", fake_remove_cosmic_rays)
+
+    raster = read_spectrograph_lvl2(sns_sg_file)
+    key = next(iter(raster.keys()))
+    sequence = raster[key]
+    cleaned_sequence = sequence.remove_cosmic_rays(
+        method="astroscrappy",
+        sigma=5.0,
+        max_iters=5,
+        method_kwargs={"batch_size": 16},
+    )
+
+    assert cleaned_sequence is sequence
+    assert captured["cube"] is sequence
+    assert captured["method"] == "astroscrappy"
+    assert captured["sigma"] == 5.0
+    assert captured["max_iters"] == 5
+    assert captured["method_kwargs"] == {"batch_size": 16}
+
+
+def test_spectrogram_cube_slice_slices_basic_wcs(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"][0]
+    slice_index = cube.shape[0] // 2
+
+    sliced_cube = cube[slice_index]
+    row_index = sliced_cube.shape[0] // 2
+    column_index = sliced_cube.shape[1] // 2
+
+    assert sliced_cube.basic_wcs is not None
+    assert sliced_cube.basic_wcs.pixel_n_dim == sliced_cube.wcs.pixel_n_dim == 2
+    sliced_spectral, sliced_sky = sliced_cube.basic_wcs.array_index_to_world(row_index, column_index)
+    expected_spectral, expected_sky = cube.basic_wcs.array_index_to_world(slice_index, row_index, column_index)
+    assert_quantity_allclose(sliced_spectral.to(u.nm), expected_spectral.to(u.nm))
+    assert_quantity_allclose(sliced_sky.Tx.to(u.arcsec), expected_sky.Tx.to(u.arcsec))
+    assert_quantity_allclose(sliced_sky.Ty.to(u.arcsec), expected_sky.Ty.to(u.arcsec))
+
+
+def test_spectrogram_cube_crop_slices_basic_wcs(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"][0]
+    wavelength_index = len(cube.spectral_axis) // 2
+    wavelength = cube.spectral_axis[wavelength_index]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", AstropyUserWarning)
+        warnings.simplefilter("ignore", UnitsWarning)
+        image = cube.crop(
+            [SpectralCoord(wavelength), None, None, None],
+            [SpectralCoord(wavelength), None, None, None],
+        )
+    row_index = image.shape[0] // 2
+    column_index = image.shape[1] // 2
+
+    assert image.basic_wcs is not None
+    assert image.basic_wcs.pixel_n_dim == image.wcs.pixel_n_dim == 2
+    image_sky = image.basic_wcs.array_index_to_world(row_index, column_index)
+    _, expected_sky = cube.basic_wcs.array_index_to_world(row_index, column_index, wavelength_index)
+    assert_quantity_allclose(image_sky.Tx.to(u.arcsec), expected_sky.Tx.to(u.arcsec))
+    assert_quantity_allclose(image_sky.Ty.to(u.arcsec), expected_sky.Ty.to(u.arcsec))
+
+
+def test_spectrogram_cube_sequence_slice_preserves_type_and_common_axis(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    sequence = raster["Si IV 1403"]
+
+    sliced_sequence = sequence[:3]
+
+    assert isinstance(sliced_sequence, type(sequence))
+    assert len(sliced_sequence) == 3
+    assert getattr(sliced_sequence, "_common_axis", None) == getattr(sequence, "_common_axis", None)
+    assert sliced_sequence[0].shape == sequence[0].shape
+
+
+def _get_coord(ax, default_label):
+    for coord in ax.coords:
+        if coord.default_label.lower() == default_label:
+            return coord
+    pytest.fail(f"Coordinate '{default_label}' not found.")
+
+
+def test_raster_animation_defaults_to_longitude_axis(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"][0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", NDCubeUserWarning)
+        fig = plt.figure()
+        animator = cube.plot(fig=fig, plot_axes=["x", "y", None], vmin=0, vmax=1000)
+    ax = animator.axes
+
+    longitude = _get_coord(ax, "helioprojective longitude")
+    latitude = _get_coord(ax, "helioprojective latitude")
+    time = _get_coord(ax, "seconds from start (s)")
+
+    assert longitude.get_ticks_position() == ["b", "r"]
+    assert longitude.get_axislabel_position() == ["b", "r"]
+    assert latitude.get_ticks_position() == ["l"]
+    assert latitude.get_axislabel_position() == ["l"]
+    assert time.get_ticks_position() == ["#"]
+    assert time.get_axislabel() == ""
+    plt.close(fig)
+
+
+def test_default_raster_animation_keeps_wavelength_on_bottom(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"][0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", NDCubeUserWarning)
+        fig = plt.figure()
+        animator = cube.plot(fig=fig)
+    ax = animator.axes
+
+    wavelength = _get_coord(ax, "wavelength")
+
+    assert wavelength.get_ticks_position() == ["b", "#"]
+    assert wavelength.get_axislabel_position() == ["b", "#"]
+    plt.close(fig)
+
+
+def test_raster_animation_can_show_time_axis(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"][0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", NDCubeUserWarning)
+        fig = plt.figure()
+        animator = cube.plot(
+            fig=fig,
+            plot_axes=["x", "y", None],
+            axes_coordinates=["time", "custom:pos.helioprojective.lat", None],
+            vmin=0,
+            vmax=1000,
+        )
+    ax = animator.axes
+
+    longitude = _get_coord(ax, "helioprojective longitude")
+    latitude = _get_coord(ax, "helioprojective latitude")
+    time = _get_coord(ax, "seconds from start (s)")
+
+    assert time.get_ticks_position() == ["b"]
+    assert time.get_axislabel_position() == ["b"]
+    assert latitude.get_ticks_position() == ["l"]
+    assert latitude.get_axislabel_position() == ["l"]
+    assert longitude.get_ticks_position() == ["r"]
+    assert longitude.get_axislabel_position() == ["r"]
+    plt.close(fig)
+
+
+def test_raster_animation_keeps_longitude_axis_after_slider_update(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"][0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", NDCubeUserWarning)
+        fig = plt.figure()
+        animator = cube.plot(fig=fig, plot_axes=["x", "y", None], vmin=0, vmax=1000)
+
+    class _DummyText:
+        def set_text(self, _):
+            return None
+
+    slider = SimpleNamespace(cval=0, slider_ind=0, valtext=_DummyText())
+    animator.update_plot(1, animator.im, slider)
+    ax = animator.axes
+
+    longitude = _get_coord(ax, "helioprojective longitude")
+    latitude = _get_coord(ax, "helioprojective latitude")
+    time = _get_coord(ax, "seconds from start (s)")
+
+    assert longitude.get_ticks_position() == ["b", "r"]
+    assert longitude.get_axislabel_position() == ["b", "r"]
+    assert latitude.get_ticks_position() == ["l"]
+    assert time.get_ticks_position() == ["#"]
+    assert time.get_axislabel() == ""
+    plt.close(fig)
+
+
+def test_raster_sequence_animation_defaults_to_longitude_axis(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    sequence = raster["Si IV 1403"]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", NDCubeUserWarning)
+        fig = plt.figure()
+        animator = sequence.plot(fig=fig, plot_axes=["x", "y", None], vmin=0, vmax=1000)
+    ax = animator.axes
+
+    longitude = _get_coord(ax, "helioprojective longitude")
+    latitude = _get_coord(ax, "helioprojective latitude")
+    time = _get_coord(ax, "seconds from start (s)")
+
+    assert longitude.get_ticks_position() == ["b", "r"]
+    assert longitude.get_axislabel_position() == ["b", "r"]
+    assert latitude.get_ticks_position() == ["l"]
+    assert latitude.get_axislabel_position() == ["l"]
+    assert time.get_ticks_position() == ["#"]
+    assert time.get_axislabel() == ""
+    plt.close(fig)
+
+
+def test_raster_sequence_animation_keeps_requested_axis_after_slider_update(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    sequence = raster["Si IV 1403"]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", NDCubeUserWarning)
+        fig = plt.figure()
+        animator = sequence.plot(
+            fig=fig,
+            plot_axes=["x", "y", None],
+            axes_coordinates=["time", "custom:pos.helioprojective.lat", None],
+            vmin=0,
+            vmax=1000,
+        )
+
+    class _DummyText:
+        def set_text(self, _):
+            return None
+
+    slider = SimpleNamespace(cval=0, slider_ind=0, valtext=_DummyText())
+    animator.update_plot(1, animator.im, slider)
+    ax = animator.axes
+
+    longitude = _get_coord(ax, "helioprojective longitude")
+    latitude = _get_coord(ax, "helioprojective latitude")
+    time = _get_coord(ax, "seconds from start (s)")
+
+    assert time.get_ticks_position() == ["b"]
+    assert time.get_axislabel_position() == ["b"]
+    assert latitude.get_ticks_position() == ["l"]
+    assert latitude.get_axislabel_position() == ["l"]
+    assert longitude.get_ticks_position() == ["r"]
+    assert longitude.get_axislabel_position() == ["r"]
+    plt.close(fig)

--- a/irispy/utils/_sequence.py
+++ b/irispy/utils/_sequence.py
@@ -1,0 +1,11 @@
+"""Private helpers for ndcube sequence interoperability."""
+
+
+def get_sequence_common_axis(sequence):
+    """
+    Return a sequence common axis.
+
+    ndcube does not expose a public accessor for this value, so irispy keeps
+    the private attribute access in one place until upstream provides one.
+    """
+    return getattr(sequence, "_common_axis", None)

--- a/irispy/utils/cosmic_rays.py
+++ b/irispy/utils/cosmic_rays.py
@@ -2,11 +2,14 @@
 Utilities for removing cosmic rays from IRIS data.
 """
 
+from copy import deepcopy
 from typing import Any
 from importlib import import_module
 from collections.abc import Mapping
 
 import numpy as np
+
+from irispy.utils._sequence import get_sequence_common_axis
 
 __all__ = ["remove_cosmic_rays"]
 
@@ -92,8 +95,9 @@ def remove_cosmic_rays(
 
     Parameters
     ----------
-    cube : irispy.sji.SJICube or irispy.spectrograph.SpectrogramCube
-        Cube object to clean.
+    cube : irispy.sji.SJICube, irispy.spectrograph.SpectrogramCube, \
+           or irispy.spectrograph.SpectrogramCubeSequence
+        Cube or sequence object to clean.
     method : ``{"rsliding", "astroscrappy"}``, optional
         Cosmic ray removal backend. ``"rsliding"`` is the default and operates on
         the full array. ``"astroscrappy"`` is applied frame-by-frame over the last
@@ -109,9 +113,28 @@ def remove_cosmic_rays(
 
     Returns
     -------
-    irispy.sji.SJICube or irispy.spectrograph.SpectrogramCube
-        A new cube with cleaned data and copied metadata/coordinates.
+    irispy.sji.SJICube, irispy.spectrograph.SpectrogramCube, or
+    irispy.spectrograph.SpectrogramCubeSequence
+        A new cube or sequence with cleaned data and copied metadata/coordinates.
     """
+    from irispy.spectrograph import SpectrogramCubeSequence  # NOQA: PLC0415
+
+    if isinstance(cube, SpectrogramCubeSequence):
+        return type(cube)(
+            [
+                remove_cosmic_rays(
+                    subcube,
+                    method=method,
+                    sigma=sigma,
+                    max_iters=max_iters,
+                    method_kwargs=method_kwargs,
+                )
+                for subcube in cube
+            ],
+            meta=deepcopy(cube.meta),
+            common_axis=get_sequence_common_axis(cube),
+        )
+
     method = method.lower()
     working_mask = np.zeros(cube.data.shape, dtype=bool) if cube.mask is None else np.asarray(cube.mask, dtype=bool)
     if np.issubdtype(cube.data.dtype, np.floating):

--- a/irispy/utils/spectrograph.py
+++ b/irispy/utils/spectrograph.py
@@ -2,6 +2,8 @@
 This module provides general utility functions called by code in spectrograph.
 """
 
+from copy import deepcopy
+
 import numpy as np
 
 import astropy.units as u
@@ -11,6 +13,7 @@ from ndcube.wcs.tools import unwrap_wcs_to_fitswcs
 
 from irispy.spectrograph import SpectrogramCube, SpectrogramCubeSequence
 from irispy.utils.constants import RADIANCE_UNIT, SLIT_WIDTH
+from irispy.utils._sequence import get_sequence_common_axis
 from irispy.utils.response import get_interpolated_effective_area, get_latest_response
 
 __all__ = [
@@ -19,6 +22,24 @@ __all__ = [
     "radiometric_calibration",
     "reshape_1d_wavelength_dimensions_for_broadcast",
 ]
+
+
+def _get_calibration_fits_wcs(cube):
+    """
+    Return the FITS WCS used to derive spectral dispersion and slit solid angle.
+
+    Raster cubes may carry a gWCS on ``cube.wcs`` and a FITS WCS bridge on
+    ``cube.basic_wcs``. This helper prefers a direct FITS WCS and falls back to
+    unwrapping sliced FITS-WCS adapters when needed.
+    """
+    if hasattr(cube.wcs, "wcs"):
+        return cube.wcs.wcs
+    basic_wcs = getattr(cube, "basic_wcs", None)
+    if basic_wcs is not None:
+        if hasattr(basic_wcs, "wcs"):
+            return basic_wcs.wcs
+        return unwrap_wcs_to_fitswcs(basic_wcs)[0].wcs
+    return unwrap_wcs_to_fitswcs(cube.wcs)[0].wcs
 
 
 def radiometric_calibration(
@@ -35,11 +56,10 @@ def radiometric_calibration(
     Which is different from the IDL code as does not take spectral dispersion into account.
     If you want the same results as the IDL code, can multiply the output by the spectral dispersion.
 
-    The spectral dispersion and solid angle are calculated using the WCS information.
-    The wavelength axis and spatial axis should be determined dynamically from the WCS, rather than assuming fixed axis indices.
-    For example, the spectral dispersion is calculated as ``cube.wcs.wcs.cdelt[wavelength_axis] * cube.wcs.wcs.cunit[wavelength_axis]``,
-    and the solid angle as ``cube.wcs.wcs.cdelt[spatial_axis] * cube.wcs.wcs.cunit[spatial_axis] * SLIT_WIDTH``,
-    where ``wavelength_axis`` and ``spatial_axis`` are determined from the WCS.
+    The spectral dispersion and solid angle are calculated using an underlying FITS WCS.
+    For FITS-WCS-backed cubes this comes directly from ``cube.wcs``; for raster gWCS-backed cubes
+    it falls back to ``cube.basic_wcs``. The wavelength axis and spatial axis are determined
+    dynamically from that WCS rather than assuming fixed axis indices.
 
     Parameters
     ----------
@@ -49,7 +69,13 @@ def radiometric_calibration(
     Returns
     -------
     `irispy.spectrograph.SpectrogramCube` or `irispy.spectrograph.SpectrogramCubeSequence`
-        New cube in new units.
+        New cube in radiance units.
+
+    Raises
+    ------
+    ValueError
+        If the input does not expose a spectral axis, for example a
+        fixed-wavelength raster image.
 
     Notes
     -----
@@ -62,9 +88,13 @@ def radiometric_calibration(
     Notice the extra :math:`Å^{-1}` in the units.
     """
     if isinstance(cube, SpectrogramCubeSequence):
-        return SpectrogramCubeSequence([radiometric_calibration(c) for c in cube])
+        return SpectrogramCubeSequence(
+            [radiometric_calibration(c) for c in cube],
+            meta=deepcopy(cube.meta),
+            common_axis=get_sequence_common_axis(cube),
+        )
     detector_type = cube.meta.detector
-    underlying_wcs = unwrap_wcs_to_fitswcs(cube.wcs)[0].wcs if not hasattr(cube.wcs, "wcs") else cube.wcs.wcs
+    underlying_wcs = _get_calibration_fits_wcs(cube)
     # Get spectral dispersion per pixel.
     spectral_wcs_index = np.where(np.array(underlying_wcs.ctype) == "WAVE")[0][0]
     spectral_dispersion_per_pixel = underlying_wcs.cdelt[spectral_wcs_index] * underlying_wcs.cunit[spectral_wcs_index]
@@ -73,11 +103,18 @@ def radiometric_calibration(
     lat_wcs_index = np.arange(len(underlying_wcs.ctype))[lat_wcs_index][0]
     solid_angle = underlying_wcs.cdelt[lat_wcs_index] * underlying_wcs.cunit[lat_wcs_index] * SLIT_WIDTH
     # Get wavelength for each pixel.
-    wavelength_axis_index = next(
-        axis
-        for axis, physical_types in enumerate(cube.array_axis_physical_types)
-        if physical_types and "em.wl" in physical_types
-    )
+    try:
+        wavelength_axis_index = next(
+            axis
+            for axis, physical_types in enumerate(cube.array_axis_physical_types)
+            if physical_types and "em.wl" in physical_types
+        )
+    except StopIteration as exc:
+        msg = (
+            "radiometric_calibration requires a spectral axis. "
+            "Fixed-wavelength raster images are not supported."
+        )
+        raise ValueError(msg) from exc
     wavelength = cube.axis_world_coords(wavelength_axis_index)[0]
     time_obs = cube.meta.date_reference
     iris_response = get_latest_response(time_obs)
@@ -100,16 +137,15 @@ def radiometric_calibration(
     new_data = new_data_quantities[0].value
     new_uncertainty = new_data_quantities[1].value if len(new_data_quantities) > 1 else None
     new_unit = new_data_quantities[0].unit
-    new_cube = SpectrogramCube(
-        new_data,
-        cube.wcs,
-        new_uncertainty,
-        new_unit,
-        cube.meta,
-        mask=cube.mask,
+    return cube.to_nddata(
+        data=new_data,
+        uncertainty=new_uncertainty,
+        unit=new_unit,
+        nddata_type=type(cube),
+        extra_coords="copy",
+        global_coords="copy",
+        _basic_wcs=getattr(cube, "basic_wcs", None),
     )
-    new_cube._extra_coords = cube.extra_coords
-    return new_cube
 
 
 def convert_photons_per_sec_to_radiance(

--- a/irispy/utils/tests/test_cosmic_rays.py
+++ b/irispy/utils/tests/test_cosmic_rays.py
@@ -4,6 +4,8 @@ import types
 import numpy as np
 import pytest
 
+from irispy.io.utils import read_files
+from irispy.spectrograph import SpectrogramCubeSequence
 from irispy.utils.cosmic_rays import remove_cosmic_rays
 
 
@@ -143,6 +145,32 @@ def test_remove_cosmic_rays_astroscrappy_inmask_combined(sns_sjicube_1330, monke
     assert len(calls) == 2
     np.testing.assert_array_equal(calls[0], mask[0] | inmask[0])
     np.testing.assert_array_equal(calls[1], mask[1] | inmask[1])
+
+
+def test_remove_cosmic_rays_supports_spectrogram_cube_sequence(raster_sg_files, monkeypatch):
+    class FakeSlidingSigmaClipping:
+        def __init__(self, data, **kwargs):  # NOQA: ARG002
+            self.clipped = np.ma.masked_array(data.copy(), mask=np.zeros_like(data, dtype=bool))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "rsliding",
+        types.SimpleNamespace(SlidingSigmaClipping=FakeSlidingSigmaClipping),
+    )
+
+    sequence = read_files(raster_sg_files[:2])["Si IV 1403"]
+    cleaned_sequence = remove_cosmic_rays(sequence, method="rsliding")
+
+    assert isinstance(cleaned_sequence, SpectrogramCubeSequence)
+    assert len(cleaned_sequence) == len(sequence)
+    assert getattr(cleaned_sequence, "_common_axis", None) == getattr(sequence, "_common_axis", None)
+    assert set(cleaned_sequence.meta.keys()) == set(sequence.meta.keys())
+    assert cleaned_sequence[0].basic_wcs is not None
+    np.testing.assert_array_equal(cleaned_sequence[0].mask, sequence[0].mask)
+    np.testing.assert_allclose(
+        cleaned_sequence[0].data[~sequence[0].mask],
+        sequence[0].data[~sequence[0].mask],
+    )
 
 
 @pytest.mark.parametrize("method", ["rsliding", "astroscrappy"])

--- a/irispy/utils/tests/test_spectrograph.py
+++ b/irispy/utils/tests/test_spectrograph.py
@@ -3,6 +3,7 @@ import pytest
 from scipy.io import readsav
 
 import astropy.units as u
+from astropy.coordinates import SpectralCoord
 from astropy.tests.helper import assert_quantity_allclose
 
 from sunpy.time import parse_time
@@ -32,10 +33,11 @@ def test_calculate_dn_to_radiance_factor(sns_sg_file, idl_input_rad_cal, idl_out
     cube = raster_collection["C II 1336"][0]
     idl_wavelength = idl_input_rad_cal["wavelength"] * u.Angstrom
     idl_factor_cgs = idl_output_rad_cal["factor"]
+    basic_wcs = cube.basic_wcs.wcs
 
-    spectral_dispersion_per_pixel = cube.wcs.wcs.cdelt[0] * cube.wcs.wcs.cunit[0]
+    spectral_dispersion_per_pixel = basic_wcs.cdelt[0] * basic_wcs.cunit[0]
     # The slit width is divided by 2 in the IDL code, unsure why.
-    solid_angle = cube.wcs.wcs.cdelt[1] * cube.wcs.wcs.cunit[1] * (SLIT_WIDTH / 2)
+    solid_angle = basic_wcs.cdelt[1] * basic_wcs.cunit[1] * (SLIT_WIDTH / 2)
     iris_response = get_latest_response(parse_time("2025-01-01"))
     factor = calculate_dn_to_radiance_factor(
         iris_response=iris_response,
@@ -99,12 +101,41 @@ def test_radiometric_calibration_single_sliced_raster_cube(sns_sg_file):
     assert np.array_equal(calibrated_slice.mask, expected_slice.mask)
 
 
+def test_radiometric_calibration_raster_sequence_preserves_metadata(raster_sg_files):
+    raster_collection = read_files(raster_sg_files[:2])
+    sequence = raster_collection["Si IV 1403"]
+
+    new_sequence = radiometric_calibration(sequence)
+
+    assert isinstance(new_sequence, SpectrogramCubeSequence)
+    assert len(new_sequence) == len(sequence)
+    assert getattr(new_sequence, "_common_axis", None) == getattr(sequence, "_common_axis", None)
+    assert set(new_sequence.meta.keys()) == set(sequence.meta.keys())
+    assert new_sequence[0].basic_wcs is not None
+    assert new_sequence[0].unit == u.erg / (u.cm**2 * u.s * u.sr * u.AA)
+    assert np.any(new_sequence[0].data != sequence[0].data)
+
+
+def test_radiometric_calibration_rejects_fixed_wavelength_raster_images(sns_sg_file):
+    raster_collection = read_files(sns_sg_file)
+    cube = raster_collection["C II 1336"][0]
+    wavelength = cube.spectral_axis[5]
+    image = cube.crop(
+        [SpectralCoord(wavelength), None, None, None],
+        [SpectralCoord(wavelength), None, None, None],
+    )
+
+    with pytest.raises(ValueError, match="requires a spectral axis"):
+        radiometric_calibration(image)
+
+
 def test_convert_photons_per_sec_to_radiance_vs_peter_young(sns_sg_file):
     raster_collection = read_files(sns_sg_file)
     cube = raster_collection["C II 1336"][0]
+    basic_wcs = cube.basic_wcs.wcs
 
-    solid_angle = cube.wcs.wcs.cdelt[1] * cube.wcs.wcs.cunit[1] * (SLIT_WIDTH)
-    spectral_dispersion_per_pixel = cube.wcs.wcs.cdelt[0] * cube.wcs.wcs.cunit[0]
+    solid_angle = basic_wcs.cdelt[1] * basic_wcs.cunit[1] * (SLIT_WIDTH)
+    spectral_dispersion_per_pixel = basic_wcs.cdelt[0] * basic_wcs.cunit[0]
     iris_response = get_latest_response(parse_time("2014-09-10"))
     factor = calculate_dn_to_radiance_factor(
         iris_response=iris_response,

--- a/irispy/visualization.py
+++ b/irispy/visualization.py
@@ -6,11 +6,12 @@ import sunpy.visualization.colormaps as cm  # NOQA: F401
 from ndcube.visualization.mpl_plotter import MatplotlibPlotter
 from ndcube.visualization.mpl_sequence_plotter import MatplotlibSequencePlotter, SequenceAnimator
 
-__all__ = ["IRISArrayAnimatorWCS", "IRISPlotter", "IRISSequencePlotter"]
+__all__ = ["IRISArrayAnimatorWCS", "IRISPlotter", "IRISSequencePlotter", "finalize_iris_plot"]
 
 
 LAT_LABELS = [
     "custom:pos.helioprojective.lat",
+    "helioprojective latitude",
     "hplt-tan",
     "hplt",
     "lat",
@@ -18,19 +19,22 @@ LAT_LABELS = [
 ]
 LON_LABELS = [
     "custom:pos.helioprojective.lon",
+    "helioprojective longitude",
     "hpln-tan",
     "hpln",
     "lon",
     "longitude",
 ]
+TIME_LABEL_PRIORITY = ["seconds from start (s)", "time (utc)", "time"]
+SCAN_STEP_LABELS = ["custom:step", "scan_step"]
 WAVELENGTH_LABELS = ["wavelength", "wave", "em.wl"]
 
 
-def set_axis_properties(ax):
+def set_axis_properties(ax, axes_coordinates=None, *, animate=False):
     """
-    Set the axis colors and labels for IRIS SJI and Raster data.
+    Set IRIS axis labels and, for raster animations, the visible scan coordinate.
     """
-    if isinstance(ax, ArrayAnimatorWCS):
+    if hasattr(ax, "axes") and not hasattr(ax, "coords"):
         ax = ax.axes
     for axis in ax.coords:
         if axis.default_label.lower() in WAVELENGTH_LABELS:
@@ -41,6 +45,21 @@ def set_axis_properties(ax):
             _set_axis_properties(axis, "Helioprojective Latitude [arcsec]", "red")
         elif axis.default_label.lower() in LON_LABELS:
             _set_axis_properties(axis, "Helioprojective Longitude [arcsec]", "black")
+    if animate:
+        _set_raster_animation_axis_properties(ax, axes_coordinates)
+
+
+def finalize_iris_plot(ax, axes_coordinates=None):
+    """
+    Store requested axis-selection state and apply IRIS-specific axis formatting.
+    """
+    ax._iris_requested_axes_coordinates = axes_coordinates
+    set_axis_properties(
+        ax,
+        axes_coordinates=axes_coordinates,
+        animate=hasattr(ax, "slider_axes"),
+    )
+    return ax
 
 
 def _set_axis_properties(axis, label, color):
@@ -60,10 +79,103 @@ def _set_axis_properties(axis, label, color):
     axis.set_axislabel(label, color=color, fontsize=8)
 
 
+def _get_matching_coords(ax, labels):
+    return [coord for coord in ax.coords if coord.default_label.lower() in labels]
+
+
+def _set_coord_position(coord, position):
+    coord.set_ticks_visible(True)
+    coord.set_ticklabel_visible(True)
+    coord.set_ticks_position(position)
+    coord.set_ticklabel_position(position)
+    coord.set_axislabel_position(position)
+
+
+def _hide_coord(coord):
+    coord.set_ticks_visible(False)
+    coord.set_ticklabel_visible(False)
+    coord.set_ticks_position("#")
+    coord.set_ticklabel_position("#")
+    coord.set_axislabel_position("#")
+    coord.set_axislabel("")
+
+
+def _has_visible_edge(coord):
+    return bool(coord.get_ticks_position())
+
+
+def _select_scan_coord_kind(axes_coordinates):
+    if axes_coordinates:
+        lowered = {coord.lower() for coord in axes_coordinates if isinstance(coord, str)}
+        if lowered.intersection(TIME_LABEL_PRIORITY):
+            return "time"
+    return "longitude"
+
+
+def _pick_time_coord(time_coords):
+    for preferred_label in TIME_LABEL_PRIORITY:
+        for coord in time_coords:
+            if coord.default_label.lower() == preferred_label:
+                return coord
+    return None
+
+
+def _set_raster_animation_axis_properties(ax, axes_coordinates):
+    """
+    Place the raster scan coordinate on the frame edge selected by the user.
+
+    Raster image animations can expose either helioprojective longitude or time
+    on the scan axis. This helper keeps latitude on the left edge, hides the
+    auxiliary scan-step helper, and moves the selected scan coordinate onto the
+    visible frame edge.
+    """
+    if not _get_matching_coords(ax, SCAN_STEP_LABELS):
+        return
+
+    wavelength_coords = _get_matching_coords(ax, WAVELENGTH_LABELS)
+    lon_coords = _get_matching_coords(ax, LON_LABELS)
+    lat_coords = _get_matching_coords(ax, LAT_LABELS)
+    time_coords = _get_matching_coords(ax, TIME_LABEL_PRIORITY)
+    if not lon_coords or not lat_coords or not time_coords:
+        return
+    if wavelength_coords and _has_visible_edge(wavelength_coords[0]):
+        return
+
+    selected_scan_kind = _select_scan_coord_kind(axes_coordinates)
+    selected_scan_coord = lon_coords[0]
+    if selected_scan_kind == "time":
+        selected_time_coord = _pick_time_coord(time_coords)
+        if selected_time_coord is not None:
+            selected_scan_coord = selected_time_coord
+
+    scan_step_coords = _get_matching_coords(ax, SCAN_STEP_LABELS)
+    for coord in scan_step_coords:
+        _hide_coord(coord)
+    for coord in time_coords:
+        if coord is not selected_scan_coord:
+            _hide_coord(coord)
+    if selected_scan_kind != "time":
+        for coord in lon_coords[1:]:
+            _hide_coord(coord)
+
+    if selected_scan_kind == "time":
+        _set_coord_position(lon_coords[0], "r")
+        _set_coord_position(selected_scan_coord, "b")
+    else:
+        _set_coord_position(selected_scan_coord, ["b", "r"])
+    _set_coord_position(lat_coords[0], "l")
+
+
 class Plot2DMixin:
-    def update_plot_2d(self, val, im, slider):
-        super().update_plot_2d(val, im, slider)
-        set_axis_properties(self.axes)
+    def update_plot(self, val, artist, slider):
+        result = super().update_plot(val, artist, slider)
+        if self.plot_dimensionality == 2:
+            set_axis_properties(
+                self.axes,
+                axes_coordinates=getattr(self, "_iris_requested_axes_coordinates", None),
+                animate=True,
+            )
+        return result
 
 
 class IRISArrayAnimatorWCS(Plot2DMixin, ArrayAnimatorWCS):
@@ -86,14 +198,9 @@ class IRISPlotter(MatplotlibPlotter):
         data_unit=None,
         **kwargs,
     ):
-        # This is a copy of the super method, but with the replacement
-        # of the ArrayAnimatorWCS with IRISArrayAnimatorWCS.
         data, wcs, plot_axes, coord_params = self._prep_animate_args(wcs, plot_axes, axes_units, data_unit)
         ax = IRISArrayAnimatorWCS(data, wcs, plot_axes, coord_params=coord_params, **kwargs)
-        # We need to modify the visible axes after the axes object has been created.
-        # This call affects only the initial draw
         self._apply_axes_coordinates(ax.axes, axes_coordinates)
-        # This changes the parameters for future iterations
         for hidden in self._not_visible_coords(ax.axes, axes_coordinates):
             param = ax.coord_params.get(hidden, {})
             param["ticks"] = False


### PR DESCRIPTION
## Summary by Sourcery

Introduce a gWCS-based WCS for IRIS raster spectrograph data and adapt raster reading and cube utilities to support richer world coordinates and cropping while preserving backward compatibility.

New Features:
- Add a custom raster gWCS implementation that combines spectral, celestial, temporal, and scan-step coordinates for IRIS spectrograph rasters.
- Expose the underlying basic celestial WCS on spectrogram cubes to enable legacy-style world-to-pixel usage alongside the new gWCS.

Enhancements:
- Refactor raster FITS header handling and observer construction into helpers to normalize units, account for slit offsets, and support V34 scan reversals more robustly.
- Update SpectrogramCube to preserve time information in a friendlier format, carry basic WCS through slicing, and provide a crop implementation compatible with both the legacy raster API and the new gWCS.
- Adjust tests to validate the new raster gWCS structure, crop behavior, inverse transformations, and consistency between gWCS and the basic WCS.

Tests:
- Extend spectrograph IO and spectrograph cube tests to cover gWCS dimensions, time formatting, crop semantics, inverse round-tripping, and agreement with the basic WCS.