### PR TITLE
Added the ability to caculate moments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 exclude: "(.*/)?CITATION.rst$|.*(.fits|.fts|.fit|.header|.txt|tca.*|extern.*|irispy/extern)$"
+
 repos:
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.23.1
@@ -16,6 +17,13 @@ repos:
       - id: ruff-format
         types: [python]
         exclude: *exclude_dirs
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.8
+    hooks:
+      - id: docformatter
+        args: ["--black", "--pre-summary-newline", "--pre-summary-space", "--make-summary-multi-line", "--close-quotes-on-newline", "--in-place"]
+        types: [python]
+        exclude: examples/
   - repo: https://github.com/PyCQA/isort
     rev: 8.0.1
     hooks:

--- a/changelog/124.feature.rst
+++ b/changelog/124.feature.rst
@@ -1,0 +1,1 @@
+Added a way to calculate the moments for a SpectrumCube with an example: :ref:`sphx_glr_generated_gallery_analysis_04_spectral_moments.py`.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,14 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile clean
+
+# Custom clean target: remove Sphinx build output and all generated content
+clean:
+	rm -rf $(BUILDDIR)
+	rm -rf api
+	rm -rf generated
+	rm -f sg_execution_times.rst
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -216,8 +216,8 @@ def jinja_to_rst(app, docname, source):
 
     Depending on the building format, we render the page as a jinja template.
 
-    For the linkchecker, we bypass templating as it doesn't support jinja, but we
-    remove the jinja blocks so the page is still valid for checking.
+    For the linkchecker, we bypass templating as it doesn't support jinja, but we remove
+    the jinja blocks so the page is still valid for checking.
     """
     jinja_pages = ["index"]
     if app.builder.format == "html":

--- a/docs/reference/utils.rst
+++ b/docs/reference/utils.rst
@@ -12,6 +12,8 @@ The `irispy.utils` module provides functions useful for ``irispy`` users or deve
 
 .. automodapi:: irispy.utils.dust
 
+.. automodapi:: irispy.utils.moments
+
 .. automodapi:: irispy.utils.response
 
 .. automodapi:: irispy.utils.spectrograph

--- a/examples/analysis/01_spectral_fitting.py
+++ b/examples/analysis/01_spectral_fitting.py
@@ -5,6 +5,10 @@ Fit Spectral Models to Spectra
 
 In this example, we are going to fit spectral lines from IRIS, using the raster data
 with a single Gaussian. Then use the fitted values to calculate the Gaussian moments.
+
+This is direct contrast to taking the spectral moments of the data cube, which is done in
+the following example, :ref:`sphx_glr_generated_gallery_analysis_04_spectral_moments.py`
+where we calculate the spectral moments of the data cube directly.
 """
 
 import shutil
@@ -39,6 +43,7 @@ time_support()
 #
 # The full observation is at https://www.lmsal.com/hek/hcr?cmd=view-event&event-id=ivo%3A%2F%2Fsot.lmsal.com%2FVOEvent%23VOEvent_IRIS_20180102_153155_3610108077_2018-01-02T15%3A31%3A552018-01-02T15%3A31%3A55.xml
 #
+
 raster_filename = pooch.retrieve(
     "http://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2018/01/02/20180102_153155_3610108077/iris_l2_20180102_153155_3610108077_raster.tar.gz",
     known_hash="8949562149cfa5fba067b5b102e8434b14cea3c3416dd79c06b7f6e211c61a39",
@@ -76,12 +81,6 @@ si_iv_core = 140.277 * u.nm
 lower_corner = [SpectralCoord(si_iv_core), None]
 upper_corner = [SpectralCoord(si_iv_core), None]
 si_iv_spec_crop = si_iv_1403.crop(lower_corner, upper_corner)
-
-fig = plt.figure()
-ax = fig.add_subplot(111, projection=si_iv_spec_crop.wcs)
-si_iv_spec_crop.plot(axes=ax, plot_axes=["x", "y"], vmin=0, vmax=200)
-plt.title("Si IV 1402.77 A")
-plt.colorbar(label="Intensity [DN]", shrink=0.8)
 
 ###############################################################################
 # We will want to make two rebinned cubes from the full raster,
@@ -207,7 +206,16 @@ if errors:
 # Let us see the output!
 
 # Note that we are transposing the data arrays so they match up with the projection which is in X,Y.
-fig, axs = plt.subplots(nrows=3, ncols=1, subplot_kw={"projection": si_iv_spec_crop}, figsize=(6, 16))
+fig, ax_dict = plt.subplot_mosaic(
+    [["fov", "net_flux"], ["velocity", "sigma"]],
+    subplot_kw={"projection": si_iv_spec_crop.wcs},
+    figsize=(12, 10),
+)
+
+si_iv_spec_crop.plot(axes=ax_dict["fov"], plot_axes=["x", "y"], vmin=0, vmax=200)
+ax_dict["fov"].set_title("Si IV 1402.77 A")
+fig.colorbar(ax_dict["fov"].images[0], ax=ax_dict["fov"], label="Intensity [DN]", shrink=0.8)
+
 net_flux = (
     np.sqrt(2 * np.pi)
     * (iris_model_fit.amplitude_1)
@@ -215,31 +223,31 @@ net_flux = (
     / np.mean(si_iv_1403.axis_world_coords("wl")[0][1:] - si_iv_1403.axis_world_coords("wl")[0][:-1]).to(u.nm)
 )
 amp_max = np.nanpercentile(np.abs(net_flux.value), 99)
-amp = axs[0].imshow(net_flux.value.T, vmin=0, vmax=amp_max, origin="lower")
-cbar = fig.colorbar(amp, ax=axs[0])
+amp = ax_dict["net_flux"].imshow(net_flux.value.T, vmin=0, vmax=amp_max, origin="lower")
+cbar = fig.colorbar(amp, ax=ax_dict["net_flux"])
 cbar.set_label(label=f"Intensity [{net_flux.unit.to_string()}]", fontsize=8)
 cbar.ax.tick_params(labelsize=8)
-axs[0].set_title("Gaussian Net Flux")
+ax_dict["net_flux"].set_title("Gaussian Net Flux")
 
 core_shift = ((iris_model_fit.mean_1.quantity.to(u.nm)) - si_iv_core) / si_iv_core * (constants.c.to(u.km / u.s))
 shift_max = np.nanpercentile(np.abs(core_shift.value), 95)
-shift = axs[1].imshow(core_shift.value.T, cmap="coolwarm", vmin=-shift_max, vmax=shift_max)
-cbar = fig.colorbar(shift, ax=axs[1], extend="both")
+shift = ax_dict["velocity"].imshow(core_shift.value.T, cmap="coolwarm", vmin=-shift_max, vmax=shift_max)
+cbar = fig.colorbar(shift, ax=ax_dict["velocity"], extend="both")
 cbar.set_label(label=f"Doppler shift [{core_shift.unit.to_string()}]", fontsize=8)
 cbar.ax.tick_params(labelsize=8)
-axs[1].set_title("Velocity from Gaussian shift")
+ax_dict["velocity"].set_title("Velocity from Gaussian shift")
 
 sigma = (iris_model_fit.stddev_1.quantity.to(u.nm)) / si_iv_core * (constants.c.to(u.km / u.s))
 # We make any negative values nan for the purpose of the color scale.
 sigma = np.where(sigma < 0, np.nan, sigma)
 line_max = np.nanpercentile(np.abs(sigma.value), 95)
-line = axs[2].imshow(sigma.value.T, vmax=line_max)
-cbar = fig.colorbar(line, ax=axs[2])
+line = ax_dict["sigma"].imshow(sigma.value.T, vmax=line_max)
+cbar = fig.colorbar(line, ax=ax_dict["sigma"])
 cbar.set_label(label=f"Line Width [{sigma.unit.to_string()}]", fontsize=8)
 cbar.ax.tick_params(labelsize=8)
-axs[2].set_title("Gaussian Sigma")
+ax_dict["sigma"].set_title("Gaussian Sigma")
 
-for ax in axs:
+for ax in ax_dict.values():
     ax.coords[0].set_ticklabel(exclude_overlapping=True, fontsize=8)
     ax.coords[0].set_axislabel("Helioprojective Longitude", fontsize=8)
     ax.coords[1].set_ticklabel(exclude_overlapping=True, fontsize=8)
@@ -248,4 +256,4 @@ fig.tight_layout()
 
 plt.show()
 
-# sphinx_gallery_thumbnail_number = 3
+# sphinx_gallery_thumbnail_number = 2

--- a/examples/analysis/04_spectral_moments.py
+++ b/examples/analysis/04_spectral_moments.py
@@ -1,0 +1,151 @@
+"""
+===============================
+Calculate Spectral Line Moments
+===============================
+
+In this example, we are going to calculate the spectral moments from IRIS raster data.
+Moments provide a model-independent way to characterize spectral lines:
+
+* 0th moment gives the total intensity
+* 1st moment gives the centroid (Doppler shift)
+* 2nd moment gives the line width
+
+This is direct contrast to fitting a model to the data which is done in example
+:ref:`sphx_glr_generated_gallery_analysis_01_spectral_fitting.py` where we fit a Gaussian to the
+line profile and extract the same information from the fit parameters.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pooch
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord, SpectralCoord
+from astropy.visualization import time_support
+from astropy.wcs.utils import wcs_to_celestial_frame
+
+from sunpy.coordinates.frames import Helioprojective
+
+from irispy.io import read_files
+from irispy.utils.moments import calculate_moments
+
+time_support()
+
+###############################################################################
+# We will start by getting some data from the IRIS archive.
+#
+# In this case, we will use ``pooch`` so to keep this example self-contained
+# but using your browser will also work.
+#
+# Using the url: http://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2018/01/02/20180102_153155_3610108077/iris_l2_20180102_153155_3610108077_raster.tar.gz
+# we are after the raster sequence (~300 MB).
+#
+# The full observation is at https://www.lmsal.com/hek/hcr?cmd=view-event&event-id=ivo%3A%2F%2Fsot.lmsal.com%2FVOEvent%23VOEvent_IRIS_20180102_153155_3610108077_2018-01-02T15%3A31%3A552018-01-02T15%3A31%3A55.xml
+#
+
+raster_filename = pooch.retrieve(
+    "http://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2018/01/02/20180102_153155_3610108077/iris_l2_20180102_153155_3610108077_raster.tar.gz",
+    known_hash="8949562149cfa5fba067b5b102e8434b14cea3c3416dd79c06b7f6e211c61a39",
+)
+
+###############################################################################
+# Now to open the files using ``irispy``.
+
+# Note that when ``memmap=True``, the data values are read from the FITS file
+# directly without the scaling to Float32 (via "b_zero" and "b_scale"),
+# the data values are no longer in DN, but in scaled integer units that start at -2$^{16}$/2.
+#
+# We will use ``memmap=False`` because we want the actual the data values.
+
+raster = read_files(raster_filename, memmap=False)
+
+###############################################################################
+# We will just focus on the Si IV 1403 line which we can select using a key.
+# Then we will just plot a spectral line selected at random in space.
+
+# There is only one complete scan, so we index that away.
+si_iv_1403 = raster["Si IV 1403"][0]
+
+# However, before we get to that, we will shrink the data cube to make it easier to work with.
+iris_observer = wcs_to_celestial_frame(si_iv_1403.wcs.celestial).observer
+iris_frame = Helioprojective(observer=iris_observer)
+top_left = [None, SkyCoord(-290 * u.arcsec, 260 * u.arcsec, frame=iris_frame)]
+bottom_right = [None, SkyCoord(-360 * u.arcsec, 310 * u.arcsec, frame=iris_frame)]
+si_iv_1403 = si_iv_1403.crop(top_left, bottom_right)
+
+###############################################################################
+# Let us just check the full field of view at the line core.
+
+si_iv_core = 140.277 * u.nm
+lower_corner = [SpectralCoord(si_iv_core), None]
+upper_corner = [SpectralCoord(si_iv_core), None]
+si_iv_spec_crop = si_iv_1403.crop(lower_corner, upper_corner)
+
+################################################################################
+# Now we can calculate the spectral moments using the `~irispy.utils.moments.calculate_moments` function.
+#
+# This helper automatically extracts the wavelength coordinates from the cube's
+# WCS and computes the moments along the spectral axis for every spatial pixel.
+#
+# We will restrict the calculation to a narrow window around the rest wavelength
+# (0.05 nm = 0.5 Å on each side) to isolate the Si IV line from neighbors.
+#
+# While ``wings`` is not required, it is often a good idea to restrict the calculation to a window around the line of interest to avoid contamination from other lines or noise in the continuum.
+# The same goes for ``rest_wavelength``, which is used to calculate the velocity from the wavelength shift in the 1st moment, otherwise you get the ``centroid`` in wavelength units instead of velocity units and the same goes for the line width from the 2nd moment.
+
+moments = calculate_moments(si_iv_1403, rest_wavelength=si_iv_core, wings=0.05 * u.nm, integrated=False)
+intensity = moments["intensity"]
+centroid = moments["centroid"]
+width = moments["width"]
+velocity = moments["velocity"]
+velocity_width = moments["velocity_width"]
+
+################################################################################
+# We will now visualize the moments. Note that the output is a
+# `~irispy.spectrograph.RasterCollection` which contains 2D
+# `~irispy.spectrograph.SpectrogramCube` objects with the spatial WCS preserved from the input cube.
+#
+# Note that we are transposing the data arrays so they match up with the projection which is in X,Y.
+
+fig, ax_dict = plt.subplot_mosaic(
+    [["fov", "intensity"], ["velocity", "width"]],
+    subplot_kw={"projection": si_iv_spec_crop.wcs},
+    figsize=(12, 10),
+)
+
+si_iv_spec_crop.plot(axes=ax_dict["fov"], plot_axes=["x", "y"], vmin=0, vmax=200)
+ax_dict["fov"].set_title("Si IV 1402.77 A")
+fig.colorbar(ax_dict["fov"].images[0], ax=ax_dict["fov"], label="Intensity [DN]", shrink=0.8)
+
+# 0th moment: Total intensity
+amp_max = np.nanpercentile(np.abs(intensity.data), 99)
+amp = ax_dict["intensity"].imshow(intensity.data.T, vmin=0, vmax=amp_max, origin="lower")
+cbar = fig.colorbar(amp, ax=ax_dict["intensity"])
+cbar.set_label(label=f"Intensity [{intensity.unit.to_string()}]", fontsize=8)
+cbar.ax.tick_params(labelsize=8)
+ax_dict["intensity"].set_title("Total Intensity (0th Moment)")
+
+# 1st moment: Doppler velocity from centroid shift
+shift_max = np.nanpercentile(np.abs(velocity.data), 95)
+shift = ax_dict["velocity"].imshow(velocity.data.T, cmap="coolwarm", vmin=-shift_max, vmax=shift_max, origin="lower")
+cbar = fig.colorbar(shift, ax=ax_dict["velocity"], extend="both")
+cbar.set_label(label=f"Doppler shift [{velocity.unit.to_string()}]", fontsize=8)
+cbar.ax.tick_params(labelsize=8)
+ax_dict["velocity"].set_title("Velocity from Centroid")
+
+# 2nd moment: Line width
+wmax = np.nanpercentile(width.data, 95)
+wdisp = ax_dict["width"].imshow(width.data.T, vmax=wmax, origin="lower")
+cbar = fig.colorbar(wdisp, ax=ax_dict["width"])
+cbar.set_label(label=f"Width [{width.unit.to_string()}]", fontsize=8)
+cbar.ax.tick_params(labelsize=8)
+ax_dict["width"].set_title("Line Width (2nd Moment)")
+
+for ax in ax_dict.values():
+    ax.coords[0].set_ticklabel(exclude_overlapping=True, fontsize=8)
+    ax.coords[0].set_axislabel("Helioprojective Longitude", fontsize=8)
+    ax.coords[1].set_ticklabel(exclude_overlapping=True, fontsize=8)
+    ax.coords[1].set_axislabel("Helioprojective Latitude", fontsize=8)
+fig.tight_layout()
+
+plt.show()

--- a/examples/coalign/00_coalign_iris_aia.py
+++ b/examples/coalign/00_coalign_iris_aia.py
@@ -5,8 +5,8 @@ Co-align IRIS SJI to SDO/AIA
 
 In this example we will show how to co-align a rolled IRIS dataset to SDO/AIA.
 
-The IRIS team at LMSAL provides AIA data cubes which are coaligned to the IRIS FOV
-for each observation from https://iris.lmsal.com/search/
+The IRIS team at LMSAL provides AIA data cubes which are coaligned to the IRIS FOV for
+each observation the `IRIS data search page <https://iris.lmsal.com/search/>`__.
 
 Therefore this example is more a showcase of functionally.
 """

--- a/examples/coalign/01_reproject_iris_roll_aia.py
+++ b/examples/coalign/01_reproject_iris_roll_aia.py
@@ -6,8 +6,7 @@ Reproject IRIS SJI (rolled) to SDO/AIA
 In this example we will show how to reproject a rolled IRIS dataset to SDO/AIA.
 
 The IRIS team at LMSAL provides AIA data cubes which are coaligned to the IRIS FOV for
-each observation from
-https://iris.lmsal.com/search/
+each observation the `IRIS data search page <https://iris.lmsal.com/search/>`__.
 
 Therefore this example is more a showcase of functionally.
 """

--- a/examples/how_to/01_remove_spikes.py
+++ b/examples/how_to/01_remove_spikes.py
@@ -10,6 +10,8 @@ using the built-in ``remove_cosmic_rays()`` API in ``irispy``.
 
 The ``astroscrappy`` backend works on one 2D frame at a time and does not use
 temporal context from a time series.
+
+``irispy`` supports two backends for cosmic ray removal, they are compared in this example: :ref:`sphx_glr_generated_gallery_misc_03_compare_cosmic_ray_backends.py`.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/misc/03_compare_cosmic_ray_backends.py
+++ b/examples/misc/03_compare_cosmic_ray_backends.py
@@ -11,6 +11,9 @@ This example compares the two optional cosmic-ray-removal backends supported by
 
 You can install both optional dependencies with
 ``pip install 'irispy-lmsal[cosmic-rays]'``.
+
+This example is meant to showcase the difference in one specific case, for a general overview see
+:ref:`sphx_glr_generated_gallery_how_to_01_remove_spikes.py`.
 """
 
 import matplotlib.pyplot as plt

--- a/irispy/data/test/compress.py
+++ b/irispy/data/test/compress.py
@@ -4,57 +4,56 @@ Short script I used to create the test FITS files in this folder.
 WARNING: This overrides the original files.
 """
 
+if __name__ == "__main__":
 
-def compress(files: list) -> None:
-    from scipy.ndimage import zoom  # NOQA: PLC0415
-    from tqdm import tqdm  # NOQA: PLC0415
+    def compress(files: list) -> None:
+        from scipy.ndimage import zoom  # NOQA: PLC0415
+        from tqdm import tqdm  # NOQA: PLC0415
 
-    from astropy.io import fits  # NOQA: PLC0415
+        from astropy.io import fits  # NOQA: PLC0415
 
-    for file in tqdm(files):
-        hdus = fits.open(file)
-        sg = "SPEC" in hdus[0].header["INSTRUME"]
-        sns = hdus[0].header["NRASTERP"] == 1
-        for hdu in hdus:
-            aux = "PZTX" in hdu.header
-            hdu.verify("fix")
-            if isinstance(hdu, fits.hdu.table.TableHDU) or hdu.data is None:
-                continue
-            if aux:
-                # Only resize the sit and stare data as its 3D
-                # The raster image has steps and I want to keep them
-                if sns:
+        for file in tqdm(files):
+            hdus = fits.open(file)
+            sg = "SPEC" in hdus[0].header["INSTRUME"]
+            sns = hdus[0].header["NRASTERP"] == 1
+            for hdu in hdus:
+                aux = "PZTX" in hdu.header
+                hdu.verify("fix")
+                if isinstance(hdu, fits.hdu.table.TableHDU) or hdu.data is None:
+                    continue
+                if aux:
+                    # Only resize the sit and stare data as its 3D
+                    # The raster image has steps and I want to keep them
+                    if sns:
+                        factor = (0.1, 1)
+                        hdu.data = zoom(hdu.data, factor)
+                elif hdu.data.ndim == 1:
+                    # Can't pop out the array, resizing can cause issues
+                    # So I remove the data and move on.
+                    hdu.data = None
+                    continue
+                elif hdu.data.ndim == 2:
                     factor = (0.1, 1)
                     hdu.data = zoom(hdu.data, factor)
-            elif hdu.data.ndim == 1:
-                # Can't pop out the array, resizing can cause issues
-                # So I remove the data and move on.
-                hdu.data = None
-                continue
-            elif hdu.data.ndim == 2:
-                factor = (0.1, 1)
-                hdu.data = zoom(hdu.data, factor)
-                hdu.header["NAXIS1"] = hdu.data.shape[1]
-                hdu.header["NAXIS2"] = hdu.data.shape[0]
-                hdu.header["CRPIX1"] = hdu.header["CRPIX1"] * factor[1]
-                hdu.header["CRPIX2"] = hdu.header["CRPIX2"] * factor[0]
-            elif hdu.data.ndim == 3:
-                factor = (1, 0.1, 0.1) if sg and not sns else (0.1, 0.1, 0.1)
-                hdu.data = zoom(hdu.data, factor)
-                hdu.header["NAXIS1"] = hdu.data.shape[2]
-                hdu.header["NAXIS2"] = hdu.data.shape[1]
-                hdu.header["NAXIS3"] = hdu.data.shape[0]
-                hdu.header["CRPIX1"] = hdu.header["CRPIX1"] * factor[2]
-                hdu.header["CRPIX2"] = hdu.header["CRPIX2"] * factor[1]
-                hdu.header["CRPIX3"] = hdu.header["CRPIX3"] * factor[0]
-            else:
-                msg = "HDU with more than 3 dimensions not supported"
-                raise ValueError(msg)
-            hdu = fits.CompImageHDU(hdu.data, hdu.header)  # NOQA: PLW2901
-        hdus.writeto(f"{file}", overwrite=True)
+                    hdu.header["NAXIS1"] = hdu.data.shape[1]
+                    hdu.header["NAXIS2"] = hdu.data.shape[0]
+                    hdu.header["CRPIX1"] = hdu.header["CRPIX1"] * factor[1]
+                    hdu.header["CRPIX2"] = hdu.header["CRPIX2"] * factor[0]
+                elif hdu.data.ndim == 3:
+                    factor = (1, 0.1, 0.1) if sg and not sns else (0.1, 0.1, 0.1)
+                    hdu.data = zoom(hdu.data, factor)
+                    hdu.header["NAXIS1"] = hdu.data.shape[2]
+                    hdu.header["NAXIS2"] = hdu.data.shape[1]
+                    hdu.header["NAXIS3"] = hdu.data.shape[0]
+                    hdu.header["CRPIX1"] = hdu.header["CRPIX1"] * factor[2]
+                    hdu.header["CRPIX2"] = hdu.header["CRPIX2"] * factor[1]
+                    hdu.header["CRPIX3"] = hdu.header["CRPIX3"] * factor[0]
+                else:
+                    msg = "HDU with more than 3 dimensions not supported"
+                    raise ValueError(msg)
+                hdu = fits.CompImageHDU(hdu.data, hdu.header)  # NOQA: PLW2901
+            hdus.writeto(f"{file}", overwrite=True)
 
-
-if __name__ == "__main__":
     import argparse
     from pathlib import Path
 

--- a/irispy/io/sji.py
+++ b/irispy/io/sji.py
@@ -81,8 +81,8 @@ def _create_headers_wcs(hdulist):
 
     This has been set to have an Earth Observer at the time of the observation.
 
-    However, this only creates the WCS headers, not the full WCS objects.
-    Those are created in the SJICube class property basic_wcs.
+    However, this only creates the WCS headers, not the full WCS objects. Those are
+    created in the SJICube class property basic_wcs.
     """
     from sunpy.coordinates.ephemeris import get_body_heliographic_stonyhurst  # NOQA: PLC0415
     from sunpy.coordinates.frames import Helioprojective  # NOQA: PLC0415

--- a/irispy/tests/figure_hashes_mpl_3108_ft_261_astropy_720.json
+++ b/irispy/tests/figure_hashes_mpl_3108_ft_261_astropy_720.json
@@ -1,5 +1,6 @@
 {
   "irispy.utils.tests.test_dust.test_remove_dust_before_after_figure": "bbbeb47b8b0b81901f87be8ee1553fad5ed1683ade20bce1155d26a3f2644088",
+  "irispy.utils.tests.test_moments.test_calculate_moments_known_gaussian_figure": "9723b475774b4e71c55f00f0692667bda86eaaddf1efc4883cefb05c492ce755",
   "irispy.utils.tests.test_response.test_plot_idl_vs_python_fuv_sg": "ba253be18e2552c2d3e9c73ed70f123cf0516fbe5b96315ace3a03536f35b2b6",
   "irispy.utils.tests.test_response.test_plot_idl_vs_python_nuv_sg": "3eca254b88254afb59b11ce0ff42206e429acc5641111e3da97aa3a2c6cb2122",
   "irispy.utils.tests.test_response.test_plot_idl_vs_python_sji_1": "1a4bcb4a066913096c50eaa179b0e8a17c76bca79581a9420516d64b083b0b3f",

--- a/irispy/tests/helpers.py
+++ b/irispy/tests/helpers.py
@@ -72,7 +72,8 @@ def figure_test(test_function):
 
 
 def make_test_spectrogram_cube(data, wavelengths):
-    """Build a minimal 3-D SpectrogramCube for unit tests.
+    """
+    Build a minimal 3-D SpectrogramCube for unit tests.
 
     N.B. FITS stores axes in reverse order relative to numpy arrays:
     NAXIS1 corresponds to the last numpy axis, NAXIS2 to the penultimate,

--- a/irispy/tests/helpers.py
+++ b/irispy/tests/helpers.py
@@ -4,11 +4,17 @@ from functools import wraps
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
 import astropy
+import astropy.units as u
+from astropy.io import fits
+from astropy.wcs import WCS
 
-__all__ = ["warnings_as_errors"]
+from irispy.spectrograph import SpectrogramCube
+
+__all__ = ["make_test_spectrogram_cube", "warnings_as_errors"]
 
 
 @pytest.fixture
@@ -63,3 +69,48 @@ def figure_test(test_function):
         return ret
 
     return test_wrapper
+
+
+def make_test_spectrogram_cube(data, wavelengths):
+    """Build a minimal 3-D SpectrogramCube for unit tests.
+
+    N.B. FITS stores axes in reverse order relative to numpy arrays:
+    NAXIS1 corresponds to the last numpy axis, NAXIS2 to the penultimate,
+    and NAXIS3 to the first.  This helper assumes the wavelength axis is
+    the **last** numpy axis.
+
+    Parameters
+    ----------
+    data : `numpy.ndarray`
+        3-D array with shape ``(ny, nx, n_wavelengths)``.
+    wavelengths : `astropy.units.Quantity`
+        1-D wavelength grid.
+
+    Returns
+    -------
+    `irispy.spectrograph.SpectrogramCube`
+    """
+    header = fits.Header()
+    header["NAXIS"] = 3
+    header["NAXIS1"] = data.shape[2]
+    header["NAXIS2"] = data.shape[1]
+    header["NAXIS3"] = data.shape[0]
+    header["CRPIX1"] = 1
+    header["CRPIX2"] = 1
+    header["CRPIX3"] = 1
+    # CTYPE1 / NAXIS1 corresponds to the LAST numpy array axis (wavelength)
+    header["CTYPE1"] = "WAVE"
+    header["CUNIT1"] = str(wavelengths.unit)
+    header["CDELT1"] = float(np.mean(np.diff(wavelengths.value)))
+    header["CRVAL1"] = float(wavelengths.value[0])
+    header["CTYPE2"] = "HPLT-TAN"
+    header["CUNIT2"] = "arcsec"
+    header["CDELT2"] = 1.0
+    header["CRVAL2"] = 0.0
+    header["CTYPE3"] = "HPLN-TAN"
+    header["CUNIT3"] = "arcsec"
+    header["CDELT3"] = 1.0
+    header["CRVAL3"] = 0.0
+    wcs = WCS(header)
+    meta = {"OBSID": 1, "detector type": "FUV", "spectral window": "test"}
+    return SpectrogramCube(data, wcs=wcs, uncertainty=None, unit=u.DN, meta=meta, mask=None)

--- a/irispy/tests/test_helpers.py
+++ b/irispy/tests/test_helpers.py
@@ -1,4 +1,6 @@
-"""Tests for irispy.tests.helpers utilities."""
+"""
+Tests for irispy.tests.helpers utilities.
+"""
 
 import numpy as np
 
@@ -11,7 +13,9 @@ from irispy.tests.helpers import make_test_spectrogram_cube
 
 
 def test_make_test_spectrogram_cube_wcs_and_units():
-    """Lock in axis ordering assumptions: wavelength is the last axis."""
+    """
+    Lock in axis ordering assumptions: wavelength is the last axis.
+    """
     wavelengths = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     data = np.ones((5, 7, len(wavelengths)))
     cube = make_test_spectrogram_cube(data, wavelengths)

--- a/irispy/tests/test_helpers.py
+++ b/irispy/tests/test_helpers.py
@@ -1,0 +1,32 @@
+"""Tests for irispy.tests.helpers utilities."""
+
+import numpy as np
+
+import astropy.units as u
+from astropy.coordinates import SpectralCoord
+
+from ndcube import NDCube
+
+from irispy.tests.helpers import make_test_spectrogram_cube
+
+
+def test_make_test_spectrogram_cube_wcs_and_units():
+    """Lock in axis ordering assumptions: wavelength is the last axis."""
+    wavelengths = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    data = np.ones((5, 7, len(wavelengths)))
+    cube = make_test_spectrogram_cube(data, wavelengths)
+    assert isinstance(cube, NDCube)
+    assert cube.data.shape == (5, 7, 100)
+    # Wavelength should be the last axis
+    wcs = cube.wcs
+    assert wcs.naxis == 3
+    # Verify axis types in array order: last numpy axis is spectral
+    assert cube.array_axis_physical_types[2] == ("em.wl",)
+    # Spatial axes should be present on the first two axes
+    spatial_types = set(cube.array_axis_physical_types[0])
+    assert "custom:pos.helioprojective.lon" in spatial_types
+    assert "custom:pos.helioprojective.lat" in spatial_types
+    # Verify wavelength values round-trip
+    spectral_coords = cube.axis_world_coords(-1)
+    assert isinstance(spectral_coords[0], SpectralCoord)
+    np.testing.assert_allclose(spectral_coords[0].to_value(u.Angstrom), wavelengths.to_value(u.Angstrom))

--- a/irispy/utils/__init__.py
+++ b/irispy/utils/__init__.py
@@ -1,6 +1,7 @@
 from . import constants as constants
 from . import cosmic_rays as cosmic_rays
 from . import dust as dust
+from . import moments as moments
 from . import response as response
 from . import spectrograph as spectrograph
 from . import wobble as wobble

--- a/irispy/utils/dust.py
+++ b/irispy/utils/dust.py
@@ -75,7 +75,7 @@ def remove_dust(
     spatial_box=5,
 ):
     """
-    "Repair" dust-darkened pixels in an IRIS image cube.
+    Replace dust-darkened pixels in an IRIS image cube.
 
     This routine is inspired by SolarSoft's ``IRIS_DUSTBUSTER``. It uses
     neighboring frames at the same pixel location first, and falls back to a local

--- a/irispy/utils/moments.py
+++ b/irispy/utils/moments.py
@@ -27,7 +27,8 @@ def _make_moment_cube(template, values, unit):
     return new_cube
 
 
-@u.quantity_input(rest_wavelength=u.nm, wings=u.nm)
+# NOTE: We do not use @u.quantity_input because it cannot validate tuple
+# Quantities like ``(0.05, 0.15) * u.Angstrom`` for the ``wings`` argument.
 def calculate_moments(
     cube, *, rest_wavelength=None, wings=None, integrated=False, min_intensity=None, saturation_limit=None
 ):
@@ -57,12 +58,15 @@ def calculate_moments(
         with units of ``DN·nm``. If `False` (default), it is computed as :math:`\sum I(\lambda)`
         with units of ``DN`` (i.e., per-pixel sum, matching the convention used in
         Gaussian fitting).
-    intensity_threshold : `float`, optional
-        If given, pixels where the 0th moment is below this threshold are masked and are set to
-        NaN for those pixels.
+    min_intensity : `float`, optional
+        Minimum integrated (or per-pixel) intensity required for a pixel to be
+        considered valid. Pixels with intensity **below** this value have all
+        their moments (including intensity) set to NaN. Useful for excluding
+        noisy low-signal pixels.
     saturation_limit : `float`, optional
-        If given, pixels where any spectral bin in the (cropped) profile exceeds
-        this value are treated as saturated and are set to NaN for those pixels.
+        Maximum allowed peak intensity in any spectral bin. Pixels where any
+        bin in the (cropped) profile exceeds this value are treated as
+        saturated and have all their moments set to NaN.
 
     Returns
     -------
@@ -107,15 +111,13 @@ def calculate_moments(
     data = cube.data.copy()
     data = np.where(data < 0, 0, data)
     data = np.where(np.isfinite(data), data, 0)
-    if cube.uncertainty is not None:
-        uncertainty = cube.uncertainty.array.copy()
-        uncertainty = np.where(np.isfinite(uncertainty), uncertainty, 0)
-    else:
-        uncertainty = np.abs(data * 0.1)
     if wings is not None:
         if rest_wavelength is None:
             msg = "rest_wavelength must be provided when wings is given"
             raise ValueError(msg)
+        if not isinstance(wings, u.Quantity):
+            msg = "wings must be an astropy.units.Quantity"
+            raise TypeError(msg)
         rest_wavelength = u.Quantity(rest_wavelength)
         wavelengths_in_rest_unit = wavelengths.to(rest_wavelength.unit)
         if wings.isscalar:
@@ -134,7 +136,6 @@ def calculate_moments(
         slicer = [slice(None)] * data.ndim
         slicer[wavelength_axis] = crop_indices
         data = data[tuple(slicer)]
-        uncertainty = uncertainty[tuple(slicer)]
         wavelengths = wavelengths[crop_mask]
     # Calculate wavelength step (assumed uniform)
     dwvl = np.mean(np.diff(wavelengths))
@@ -169,14 +170,22 @@ def calculate_moments(
     stddev_value = np.sqrt(variance_value)
 
     if min_intensity is not None:
-        low_intensity = intensity_value < min_intensity
+        if isinstance(min_intensity, u.Quantity):
+            min_intensity_value = min_intensity.to_value(intensity_unit)
+        else:
+            min_intensity_value = min_intensity
+        low_intensity = intensity_value < min_intensity_value
         intensity_value = np.where(low_intensity, np.nan, intensity_value)
         centroid_value = np.where(low_intensity, np.nan, centroid_value)
         stddev_value = np.where(low_intensity, np.nan, stddev_value)
 
     if saturation_limit is not None:
         peak_value = np.max(data_moved, axis=-1)
-        saturated = peak_value > saturation_limit
+        if isinstance(saturation_limit, u.Quantity):
+            saturation_limit_value = saturation_limit.to_value(cube.unit)
+        else:
+            saturation_limit_value = saturation_limit
+        saturated = peak_value > saturation_limit_value
         intensity_value = np.where(saturated, np.nan, intensity_value)
         centroid_value = np.where(saturated, np.nan, centroid_value)
         stddev_value = np.where(saturated, np.nan, stddev_value)

--- a/irispy/utils/moments.py
+++ b/irispy/utils/moments.py
@@ -1,0 +1,215 @@
+"""
+This module provides spectral moment calculation utilities for IRIS spectrogram cubes.
+"""
+
+import numpy as np
+
+import astropy.units as u
+from astropy import constants
+
+from irispy.spectrograph import RasterCollection, SpectrogramCube
+
+__all__ = ["calculate_moments"]
+
+
+def _make_moment_cube(template, values, unit):
+    new_cube = SpectrogramCube(
+        values,
+        template.wcs,
+        None,
+        unit,
+        template.meta,
+        mask=template.mask,
+    )
+    # Preserve extra coordinates if they exist on the template
+    if hasattr(template, "_extra_coords"):
+        new_cube._extra_coords = template._extra_coords
+    return new_cube
+
+
+@u.quantity_input(rest_wavelength=u.nm, wings=u.nm)
+def calculate_moments(
+    cube, *, rest_wavelength=None, wings=None, integrated=False, min_intensity=None, saturation_limit=None
+):
+    r"""
+    Calculate the 0th, 1st, and 2nd spectral moments of a data cube.
+
+    The moments are computed along the spectral (wavelength) axis for each
+    spatial pixel:
+
+    * 0th moment: total intensity, :math:`\sum I(\lambda_i)` (or :math:`\int I(\lambda) \, d\lambda` when ``integrated=True``)
+    * 1st moment: centroid wavelength, :math:`\sum \lambda_i I(\lambda_i) / \sum I(\lambda_i)`
+    * 2nd moment: standard deviation, :math:`\sqrt{\sum (\lambda_i - \lambda_0)^2 I(\lambda_i) / \sum I(\lambda_i)}`
+
+    Parameters
+    ----------
+    cube : `irispy.spectrograph.SpectrogramCube`
+        The input data cube. Must have a spectral (wavelength) axis.
+    rest_wavelength : `astropy.units.Quantity`, optional
+        The rest wavelength of the spectral line. Required if ``wings`` is given.
+    wings : `astropy.units.Quantity`, optional
+        The spectral range around ``rest_wavelength`` to include in the calculation.
+        Must be an `~astropy.units.Quantity` with appropriate units (e.g., nm or Angstrom).
+        If a scalar Quantity, it is applied symmetrically. If a tuple of two Quantities,
+        they are the lower and upper offsets respectively.
+    integrated : `bool`, optional
+        If `True`, the 0th moment is computed as :math:`\int I(\lambda) \, d\lambda`
+        with units of ``DN·nm``. If `False` (default), it is computed as :math:`\sum I(\lambda)`
+        with units of ``DN`` (i.e., per-pixel sum, matching the convention used in
+        Gaussian fitting).
+    intensity_threshold : `float`, optional
+        If given, pixels where the 0th moment is below this threshold are masked and are set to
+        NaN for those pixels.
+    saturation_limit : `float`, optional
+        If given, pixels where any spectral bin in the (cropped) profile exceeds
+        this value are treated as saturated and are set to NaN for those pixels.
+
+    Returns
+    -------
+    `irispy.spectrograph.RasterCollection`
+        A collection containing 2D `~irispy.spectrograph.SpectrogramCube`
+        objects with the spatial WCS preserved from the input cube.
+
+        Always present:
+
+        * ``"intensity"`` — 0th moment (total intensity)
+        * ``"centroid"`` — 1st moment (centroid wavelength)
+        * ``"width"`` — 2nd moment (standard deviation)
+
+        Additionally, if ``rest_wavelength`` is provided:
+
+        * ``"velocity"`` — Doppler shift from the centroid in km/s
+        * ``"velocity_width"`` — line width converted to velocity units in km/s
+
+    Notes
+    -----
+    * Negative and non-finite (NaN/inf) data values are set to zero before computing moments.
+    * Wavelength coordinates are converted to **nm** internally, so ``centroid`` and ``width``
+      are always returned in nm.
+    * For a uniform spectral grid, the 1st and 2nd moments are identical regardless of the
+      ``integrated`` setting because the pixel spacing cancels out in the ratio.
+
+    References
+    ----------
+    * `Spectral-Cube moment maps <https://spectral-cube.readthedocs.io/en/latest/moments.html#moment-map-equations>`__
+    * `arXiv:2005.02029, Section 3.1 <https://arxiv.org/abs/2005.02029>`__
+    * `Færder et al. (2024), ApJ, Appendix C <https://iopscience.iop.org/article/10.3847/1538-4357/ac4223>`__
+    """
+    wavelength_axis = next(
+        axis
+        for axis, physical_types in enumerate(cube.array_axis_physical_types)
+        if physical_types and "em.wl" in physical_types
+    )
+    wavelengths = cube.axis_world_coords(wavelength_axis)[0]
+    if not isinstance(wavelengths, u.Quantity):
+        wavelengths = wavelengths * u.one
+    wavelengths = wavelengths.to(u.nm)
+    data = cube.data.copy()
+    data = np.where(data < 0, 0, data)
+    data = np.where(np.isfinite(data), data, 0)
+    if cube.uncertainty is not None:
+        uncertainty = cube.uncertainty.array.copy()
+        uncertainty = np.where(np.isfinite(uncertainty), uncertainty, 0)
+    else:
+        uncertainty = np.abs(data * 0.1)
+    if wings is not None:
+        if rest_wavelength is None:
+            msg = "rest_wavelength must be provided when wings is given"
+            raise ValueError(msg)
+        rest_wavelength = u.Quantity(rest_wavelength)
+        wavelengths_in_rest_unit = wavelengths.to(rest_wavelength.unit)
+        if wings.isscalar:
+            wing_low = wings
+            wing_high = wings
+        else:
+            wing_low = wings[0]
+            wing_high = wings[1]
+        wvl_min = rest_wavelength - wing_low
+        wvl_max = rest_wavelength + wing_high
+        crop_mask = (wavelengths_in_rest_unit >= wvl_min) & (wavelengths_in_rest_unit <= wvl_max)
+        crop_indices = np.where(crop_mask)[0]
+        if len(crop_indices) == 0:
+            msg = "No wavelength points found within the specified wings"
+            raise ValueError(msg)
+        slicer = [slice(None)] * data.ndim
+        slicer[wavelength_axis] = crop_indices
+        data = data[tuple(slicer)]
+        uncertainty = uncertainty[tuple(slicer)]
+        wavelengths = wavelengths[crop_mask]
+    # Calculate wavelength step (assumed uniform)
+    dwvl = np.mean(np.diff(wavelengths))
+    # Move wavelength axis to the end for vectorised computation
+    data_moved = np.moveaxis(data, wavelength_axis, -1)
+    wvls = wavelengths.value
+    # Broadcast wavelengths to match moved data shape
+    broadcast_shape = [1] * data_moved.ndim
+    broadcast_shape[-1] = -1
+    wvls_broadcast = wvls.reshape(broadcast_shape)
+    dwvl_value = dwvl.value
+    # Weights for moment calculation: integrated (x dλ) or per-pixel
+    if integrated:
+        weights = data_moved * dwvl_value
+        intensity_unit = cube.unit * dwvl.unit
+    else:
+        weights = data_moved
+        intensity_unit = cube.unit
+    # 0th moment
+    intensity_value = np.nansum(weights, axis=-1)
+    # 1st and 2nd moments are ratios where the weighting cancels out,
+    # so the result is the same for uniform dλ regardless of ``integrated``.
+    intensity_nonzero = intensity_value != 0
+    centroid_numerator = np.nansum(weights * wvls_broadcast, axis=-1)
+    with np.errstate(invalid="ignore"):
+        centroid_value = np.where(intensity_nonzero, centroid_numerator / intensity_value, np.nan)
+    # 2nd moment (variance)
+    variance_numerator = np.nansum(((wvls_broadcast - centroid_value[..., np.newaxis]) ** 2) * weights, axis=-1)
+    with np.errstate(invalid="ignore"):
+        variance_value = np.where(intensity_nonzero, variance_numerator / intensity_value, np.nan)
+    variance_value = np.where(variance_value < 0, np.nan, variance_value)
+    stddev_value = np.sqrt(variance_value)
+
+    if min_intensity is not None:
+        low_intensity = intensity_value < min_intensity
+        intensity_value = np.where(low_intensity, np.nan, intensity_value)
+        centroid_value = np.where(low_intensity, np.nan, centroid_value)
+        stddev_value = np.where(low_intensity, np.nan, stddev_value)
+
+    if saturation_limit is not None:
+        peak_value = np.max(data_moved, axis=-1)
+        saturated = peak_value > saturation_limit
+        intensity_value = np.where(saturated, np.nan, intensity_value)
+        centroid_value = np.where(saturated, np.nan, centroid_value)
+        stddev_value = np.where(saturated, np.nan, stddev_value)
+
+    # Build a 2D spatial template by slicing out the wavelength axis.
+    # This preserves the celestial WCS, mask, and meta for the new cubes.
+    template_slicer = [slice(None)] * cube.data.ndim
+    template_slicer[wavelength_axis] = 0
+    template = cube[tuple(template_slicer)]
+
+    intensity_cube = _make_moment_cube(template, intensity_value, intensity_unit)
+    centroid_cube = _make_moment_cube(template, centroid_value, wavelengths.unit)
+    width_cube = _make_moment_cube(template, stddev_value, wavelengths.unit)
+    cubes = [
+        ("intensity", intensity_cube),
+        ("centroid", centroid_cube),
+        ("width", width_cube),
+    ]
+    # Compute velocity equivalents when rest_wavelength is known
+    if rest_wavelength is not None:
+        rest_wavelength = u.Quantity(rest_wavelength)
+        with np.errstate(invalid="ignore"):
+            velocity_value = (
+                ((centroid_value * wavelengths.unit).to(rest_wavelength.unit) - rest_wavelength)
+                / rest_wavelength
+                * constants.c.to(u.km / u.s)
+            )
+            velocity_width_value = (
+                (stddev_value * wavelengths.unit).to(rest_wavelength.unit)
+                / rest_wavelength
+                * constants.c.to(u.km / u.s)
+            )
+        velocity_cube = _make_moment_cube(template, velocity_value.value, velocity_value.unit)
+        velocity_width_cube = _make_moment_cube(template, velocity_width_value.value, velocity_width_value.unit)
+        cubes.extend([("velocity", velocity_cube), ("velocity_width", velocity_width_cube)])
+    return RasterCollection(cubes, aligned_axes=tuple(range(len(template.shape))))

--- a/irispy/utils/tests/test_cosmic_rays.py
+++ b/irispy/utils/tests/test_cosmic_rays.py
@@ -115,7 +115,10 @@ def test_remove_cosmic_rays_astroscrappy_backend(sns_sjicube_1330, monkeypatch):
 
 
 def test_remove_cosmic_rays_astroscrappy_inmask_combined(sns_sjicube_1330, monkeypatch):
-    """Inmask from method_kwargs must be OR-merged with mask before each detect_cosmics call."""
+    """
+    Inmask from method_kwargs must be OR-merged with mask before each detect_cosmics
+    call.
+    """
     calls = []
 
     def fake_detect_cosmics(frame, *, inmask=None, **kwargs):  # NOQA: ARG001

--- a/irispy/utils/tests/test_moments.py
+++ b/irispy/utils/tests/test_moments.py
@@ -289,6 +289,17 @@ def test_calculate_moments_min_intensity():
     assert np.isnan(moments["width"].data[0, 0])
 
 
+def test_calculate_moments_wings_empty_window():
+    """Test that an empty wings window raises ValueError."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    spectrum = np.ones_like(wvls.value)
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    # wings range is completely outside the spectral coverage
+    with pytest.raises(ValueError, match="No wavelength points found within the specified wings"):
+        calculate_moments(cube, rest_wavelength=1500.0 * u.Angstrom, wings=1.0 * u.Angstrom)
+
+
 def test_calculate_moments_saturation_limit():
     """Test that saturation_limit masks saturated pixels."""
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
@@ -322,3 +333,46 @@ def test_calculate_moments_integrated():
     # Centroid and width should be unchanged from the non-integrated case
     assert_quantity_allclose(centroid.data[0, 0] * centroid.unit, 140.277 * u.nm, atol=0.001 * u.nm)
     assert_quantity_allclose(width.data[0, 0] * width.unit, 0.005 * u.nm, rtol=0.05)
+
+
+def test_calculate_moments_min_intensity_mixed_pixels():
+    """Test that min_intensity only masks pixels below the threshold."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    # Create a 2x2 spatial grid with different amplitudes
+    gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
+    spectrum_high = gauss(wvls.value)  # amplitude 10
+    gauss_low = Gaussian1D(amplitude=1.0, mean=1402.77, stddev=0.05)
+    spectrum_low = gauss_low(wvls.value)  # amplitude 1
+    data = np.zeros((2, 2, len(wvls)))
+    data[0, 0] = spectrum_high
+    data[0, 1] = spectrum_low
+    data[1, 0] = spectrum_low
+    data[1, 1] = spectrum_high
+    cube = make_test_spectrogram_cube(data, wvls)
+    # Threshold between the two amplitudes: low pixels masked, high pixels kept
+    moments = calculate_moments(cube, rest_wavelength=1402.77 * u.Angstrom, min_intensity=50 * u.DN)
+    # High pixels should be valid
+    assert np.isfinite(moments["intensity"].data[0, 0])
+    assert np.isfinite(moments["intensity"].data[1, 1])
+    # Low pixels should be NaN
+    assert np.isnan(moments["intensity"].data[0, 1])
+    assert np.isnan(moments["intensity"].data[1, 0])
+    assert np.isnan(moments["centroid"].data[0, 1])
+    assert np.isnan(moments["centroid"].data[1, 0])
+    assert np.isnan(moments["width"].data[0, 1])
+    assert np.isnan(moments["width"].data[1, 0])
+
+
+def test_calculate_moments_min_intensity_at_threshold():
+    """Test that pixels exactly at min_intensity are NOT masked."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
+    spectrum = gauss(wvls.value)
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    intensity_value = calculate_moments(cube, rest_wavelength=1402.77 * u.Angstrom)["intensity"].data[0, 0]
+    # Set threshold exactly equal to the intensity — should be kept
+    moments = calculate_moments(cube, rest_wavelength=1402.77 * u.Angstrom, min_intensity=intensity_value)
+    assert np.isfinite(moments["intensity"].data[0, 0])
+    assert np.isfinite(moments["centroid"].data[0, 0])
+    assert np.isfinite(moments["width"].data[0, 0])

--- a/irispy/utils/tests/test_moments.py
+++ b/irispy/utils/tests/test_moments.py
@@ -1,0 +1,324 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import astropy.units as u
+from astropy import constants
+from astropy.modeling.models import Gaussian1D
+from astropy.tests.helper import assert_quantity_allclose
+
+from irispy.io.utils import read_files
+from irispy.spectrograph import RasterCollection, SpectrogramCube
+from irispy.tests.helpers import figure_test, make_test_spectrogram_cube
+from irispy.utils.moments import calculate_moments
+
+
+def test_calculate_moments_basic(sns_sg_file):
+    """Test that calculate_moments runs on real data and returns correct shapes and units."""
+    raster_collection = read_files(sns_sg_file)
+    cube = raster_collection["C II 1336"][0]
+    rest_wvl = 1332.9 * u.Angstrom
+    moments = calculate_moments(cube, rest_wavelength=rest_wvl, wings=0.1 * u.Angstrom)
+    assert isinstance(moments, RasterCollection)
+    assert set(moments.keys()) == {"intensity", "centroid", "width", "velocity", "velocity_width"}
+    intensity = moments["intensity"]
+    centroid = moments["centroid"]
+    width = moments["width"]
+    velocity = moments["velocity"]
+    velocity_width = moments["velocity_width"]
+    # Check shapes: cube is (nt, ny, nwl), so moments should be (nt, ny)
+    assert intensity.shape == cube.shape[:-1]
+    assert centroid.shape == cube.shape[:-1]
+    assert width.shape == cube.shape[:-1]
+    assert velocity.shape == cube.shape[:-1]
+    assert velocity_width.shape == cube.shape[:-1]
+    assert isinstance(intensity, SpectrogramCube)
+    assert isinstance(centroid, SpectrogramCube)
+    assert isinstance(width, SpectrogramCube)
+    assert isinstance(velocity, SpectrogramCube)
+    assert isinstance(velocity_width, SpectrogramCube)
+    assert intensity.unit == cube.unit
+    assert centroid.unit == u.nm
+    assert width.unit == u.nm
+    assert velocity.unit == u.km / u.s
+    assert velocity_width.unit == u.km / u.s
+    finite_mask = np.isfinite(centroid.data)
+    assert np.all(
+        (centroid.data[finite_mask] * centroid.unit >= rest_wvl - 0.1 * u.Angstrom)
+        & (centroid.data[finite_mask] * centroid.unit <= rest_wvl + 0.1 * u.Angstrom)
+    )
+    assert np.all(width.data[finite_mask] >= 0)
+    assert np.all(intensity.data >= 0)
+
+
+def test_calculate_moments_sliced_cube(sns_sg_file):
+    """Test that calculate_moments works on a sliced cube and with default arguments."""
+    raster_collection = read_files(sns_sg_file)
+    cube = raster_collection["C II 1336"][0]
+    cube_slice = cube[10, :, :]
+    moments = calculate_moments(cube_slice)
+    assert set(moments.keys()) == {"intensity", "centroid", "width"}
+    assert moments["intensity"].shape == cube_slice.shape[:-1]
+    assert moments["centroid"].shape == cube_slice.shape[:-1]
+    assert moments["width"].shape == cube_slice.shape[:-1]
+
+
+def test_calculate_moments_asymmetric_wings(sns_sg_file):
+    """Test that calculate_moments works with asymmetric wings."""
+    raster_collection = read_files(sns_sg_file)
+    cube = raster_collection["C II 1336"][0]
+    rest_wvl = 1332.9 * u.Angstrom
+    moments = calculate_moments(cube, rest_wavelength=rest_wvl, wings=(0.05, 0.15) * u.Angstrom)
+    assert set(moments.keys()) == {"intensity", "centroid", "width", "velocity", "velocity_width"}
+    assert moments["intensity"].shape == cube.shape[:-1]
+    centroid = moments["centroid"]
+    finite_mask = np.isfinite(centroid.data)
+    assert np.all(
+        (centroid.data[finite_mask] * centroid.unit >= rest_wvl - 0.05 * u.Angstrom)
+        & (centroid.data[finite_mask] * centroid.unit <= rest_wvl + 0.15 * u.Angstrom)
+    )
+
+
+def test_calculate_moments_wings_without_rest_wavelength(sns_sg_file):
+    """Test that calculate_moments raises an error when wings is given without rest_wavelength."""
+    raster_collection = read_files(sns_sg_file)
+    cube = raster_collection["C II 1336"][0]
+    with pytest.raises(ValueError, match="rest_wavelength must be provided"):
+        calculate_moments(cube, wings=1.0 * u.Angstrom)
+
+
+def test_calculate_moments_known_gaussian():
+    """Test calculate_moments against a known Gaussian profile."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
+    spectrum = gauss(wvls.value)
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    moments = calculate_moments(cube, rest_wavelength=1402.77 * u.Angstrom, wings=1.0 * u.Angstrom)
+    intensity = moments["intensity"]
+    centroid = moments["centroid"]
+    width = moments["width"]
+    velocity = moments["velocity"]
+    velocity_width = moments["velocity_width"]
+    # Intensity is the per-pixel sum (default integrated=False)
+    expected_intensity = np.sum(gauss(wvls.value))
+    assert_quantity_allclose(intensity.data[0, 0] * intensity.unit, expected_intensity * u.DN, rtol=0.01)
+    # Centroid should be close to the Gaussian mean
+    assert_quantity_allclose(centroid.data[0, 0] * centroid.unit, 140.277 * u.nm, atol=0.001 * u.nm)
+    # Width should be close to the Gaussian stddev
+    assert_quantity_allclose(width.data[0, 0] * width.unit, 0.005 * u.nm, rtol=0.05)
+    # Velocity should be near zero because the Gaussian mean matches rest_wavelength
+    assert_quantity_allclose(velocity.data[0, 0] * velocity.unit, 0 * u.km / u.s, atol=1 * u.km / u.s)
+    # Velocity width: stddev/lambda0 * c
+    expected_velocity_width = (0.05 * u.Angstrom / (1402.77 * u.Angstrom) * constants.c).to(u.km / u.s)
+    assert_quantity_allclose(velocity_width.data[0, 0] * velocity_width.unit, expected_velocity_width, rtol=0.05)
+
+
+@figure_test
+def test_calculate_moments_known_gaussian_figure():
+    """Visual regression test for moment extraction on known Gaussian profiles."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    rest_wvl = 1402.77 * u.Angstrom
+    # Per-row properties: (amplitude, stddev in Å, Doppler shift in km/s)
+    row_props = [
+        (5.0, 0.03, -20.0),  # row 0: faint, narrow, blue
+        (10.0, 0.05, 0.0),  # row 1: medium, medium, rest
+        (15.0, 0.07, 20.0),  # row 2: bright, wide, red
+    ]
+    data = np.zeros((3, 3, len(wvls)))
+    for row, (amp, std, vel) in enumerate(row_props):
+        offset = (rest_wvl * vel * u.km / u.s / constants.c).to(u.Angstrom).value
+        mean_wvl = rest_wvl.value + offset
+        gauss = Gaussian1D(amplitude=amp, mean=mean_wvl, stddev=std)
+        spectrum = gauss(wvls.value)
+        data[row, :, :] = spectrum
+    cube = make_test_spectrogram_cube(data, wvls)
+    moments = calculate_moments(cube, rest_wavelength=rest_wvl, wings=0.5 * u.Angstrom)
+    intensity = moments["intensity"]
+    velocity = moments["velocity"]
+    width = moments["width"]
+    centroid = moments["centroid"]
+    fig, axes = plt.subplots(2, 2, figsize=(10, 8))
+    # Panel 1: all three Gaussian profiles overlaid
+    ax = axes[0, 0]
+    row_colors = ["C0", "k", "C3"]
+    row_labels = ["Row 0 (amp=5, std=0.03, v=-20)", "Row 1 (amp=10, std=0.05, v=0)", "Row 2 (amp=15, std=0.07, v=+20)"]
+    for row in range(3):
+        ax.step(wvls.value, data[row, 1, :], where="mid", color=row_colors[row], alpha=0.5, label=row_labels[row])
+        ax.plot(wvls.value, data[row, 1, :], "o", color=row_colors[row], markersize=3, alpha=0.7)
+        c = (centroid.data[row, 1] * centroid.unit).to(u.Angstrom).value
+        ax.axvline(c, color=row_colors[row], linestyle="--", alpha=0.7)
+    ax.set_xlabel("Wavelength [AA]")
+    ax.set_ylabel("Intensity [DN]")
+    ax.set_title("Input spectra: three different Gaussians")
+    ax.legend(loc="upper right", fontsize=7)
+    # Panel 2: intensity map (three bands: faint / medium / bright)
+    ax = axes[0, 1]
+    im = ax.imshow(intensity.data, origin="lower", cmap="viridis")
+    ax.set_title(f"Intensity [{intensity.unit}]")
+    ax.set_xlabel("x pixel")
+    ax.set_ylabel("y pixel")
+    plt.colorbar(im, ax=ax)
+    # Panel 3: velocity map (three bands: blue / white / red)
+    ax = axes[1, 0]
+    im = ax.imshow(velocity.data, origin="lower", cmap="coolwarm", vmin=-25, vmax=25)
+    ax.set_title(f"Velocity [{velocity.unit}]")
+    ax.set_xlabel("x pixel")
+    ax.set_ylabel("y pixel")
+    for row in range(3):
+        actual_v = velocity.data[row, 1]
+        ax.text(1.0, row, f"{actual_v:.1f}", ha="center", va="center", color="black", fontsize=9, fontweight="bold")
+    plt.colorbar(im, ax=ax)
+    # Panel 4: width map (three bands: narrow / medium / wide)
+    ax = axes[1, 1]
+    im = ax.imshow(width.data, origin="lower", cmap="plasma")
+    ax.set_title(f"Width [{width.unit}]")
+    ax.set_xlabel("x pixel")
+    ax.set_ylabel("y pixel")
+    plt.colorbar(im, ax=ax)
+    fig.tight_layout()
+    return fig
+
+
+def test_calculate_moments_negative_values_zeroed():
+    """Test that negative data values are treated as zero during moment calculation."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    spectrum = np.ones_like(wvls.value) * 10.0
+    spectrum[10:20] = -5.0
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    moments = calculate_moments(cube)
+    intensity = moments["intensity"]
+    centroid = moments["centroid"]
+    # Intensity should equal sum of positive values only
+    expected_intensity = np.sum(np.where(spectrum < 0, 0, spectrum))
+    assert_quantity_allclose(intensity.data[0, 0] * intensity.unit, expected_intensity * u.DN, rtol=1e-10)
+    # Centroid should be the same as if negatives were zeroed manually
+    clean_spectrum = np.where(spectrum < 0, 0, spectrum)
+    expected_centroid = np.sum(clean_spectrum * wvls.value) / np.sum(clean_spectrum)
+    assert_quantity_allclose(
+        centroid.data[0, 0] * centroid.unit, expected_centroid * u.Angstrom, atol=0.01 * u.Angstrom
+    )
+
+
+def test_calculate_moments_nan_values_zeroed():
+    """Test that NaN data values are treated as zero during moment calculation."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    spectrum = np.ones_like(wvls.value) * 10.0
+    spectrum[10:20] = np.nan
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    moments = calculate_moments(cube)
+    intensity = moments["intensity"]
+    centroid = moments["centroid"]
+    width = moments["width"]
+    # Intensity should equal sum of finite values only
+    expected_intensity = np.sum(np.where(np.isfinite(spectrum), spectrum, 0))
+    assert_quantity_allclose(intensity.data[0, 0] * intensity.unit, expected_intensity * u.DN, rtol=1e-10)
+    assert np.isfinite(centroid.data[0, 0])
+    assert np.isfinite(width.data[0, 0])
+
+
+def test_calculate_moments_zero_intensity():
+    """Test that a completely zero spectrum returns NaN centroid and width."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    spectrum = np.zeros_like(wvls.value)
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    moments = calculate_moments(cube)
+    intensity = moments["intensity"]
+    centroid = moments["centroid"]
+    width = moments["width"]
+    assert intensity.data[0, 0] == 0
+    assert np.isnan(centroid.data[0, 0])
+    assert np.isnan(width.data[0, 0])
+
+
+def test_calculate_moments_vectorized_spatial():
+    """Test that calculate_moments correctly handles different spectra per spatial pixel."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    # Pixel (0, 0): Gaussian centered at 1402.77
+    gauss_0 = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
+    # Pixel (0, 1): Gaussian centered at 1402.80 (slightly redshifted)
+    gauss_1 = Gaussian1D(amplitude=10.0, mean=1402.80, stddev=0.05)
+    spectrum_0 = gauss_0(wvls.value)
+    spectrum_1 = gauss_1(wvls.value)
+    data = np.stack([spectrum_0, spectrum_1]).reshape(1, 2, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    moments = calculate_moments(cube, rest_wavelength=1402.77 * u.Angstrom, wings=0.5 * u.Angstrom)
+    centroid = moments["centroid"]
+    velocity = moments["velocity"]
+    # Pixel (0, 0) should be near rest wavelength
+    assert_quantity_allclose(centroid.data[0, 0] * centroid.unit, 140.277 * u.nm, atol=0.001 * u.nm)
+    assert_quantity_allclose(velocity.data[0, 0] * velocity.unit, 0 * u.km / u.s, atol=1 * u.km / u.s)
+    # Pixel (0, 1) should be slightly redshifted
+    expected_centroid_1 = 140.280 * u.nm
+    expected_velocity_1 = ((140.280 * u.nm - 140.277 * u.nm) / (140.277 * u.nm) * constants.c).to(u.km / u.s)
+    assert_quantity_allclose(centroid.data[0, 1] * centroid.unit, expected_centroid_1, atol=0.001 * u.nm)
+    assert_quantity_allclose(velocity.data[0, 1] * velocity.unit, expected_velocity_1, atol=1 * u.km / u.s)
+
+
+def test_calculate_moments_wings_excludes_outside():
+    """Test that pixels outside the wings window are excluded from the calculation."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    # Create a spectrum with two peaks: one at 1402.77 (the target) and one at 1403.3 (outside wings)
+    gauss_target = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
+    gauss_outside = Gaussian1D(amplitude=20.0, mean=1403.3, stddev=0.05)
+    spectrum = gauss_target(wvls.value) + gauss_outside(wvls.value)
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    # With wings=0.1 nm = 1 A, only the target peak should be included
+    moments = calculate_moments(cube, rest_wavelength=1402.77 * u.Angstrom, wings=0.1 * u.Angstrom)
+    centroid = moments["centroid"]
+    # If the outside peak were included, centroid would be pulled to ~1403.0
+    # With wings excluding it, centroid should stay near 1402.77
+    assert_quantity_allclose(centroid.data[0, 0] * centroid.unit, 140.277 * u.nm, atol=0.001 * u.nm)
+
+
+def test_calculate_moments_min_intensity():
+    """Test that min_intensity masks low-signal pixels."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
+    spectrum = gauss(wvls.value)
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    # Threshold well above the intensity → all moments should be NaN
+    moments = calculate_moments(cube, min_intensity=1e6)
+    assert np.isnan(moments["intensity"].data[0, 0])
+    assert np.isnan(moments["centroid"].data[0, 0])
+    assert np.isnan(moments["width"].data[0, 0])
+
+
+def test_calculate_moments_saturation_limit():
+    """Test that saturation_limit masks saturated pixels."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
+    spectrum = gauss(wvls.value)
+    # Artificially saturate the peak
+    spectrum[np.argmax(spectrum)] = 1e5
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    moments = calculate_moments(cube, saturation_limit=1e4)
+    assert np.isnan(moments["intensity"].data[0, 0])
+    assert np.isnan(moments["centroid"].data[0, 0])
+    assert np.isnan(moments["width"].data[0, 0])
+
+
+def test_calculate_moments_integrated():
+    """Test that integrated=True returns intensity in DN·nm."""
+    wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
+    gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
+    spectrum = gauss(wvls.value)
+    data = spectrum.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wvls)
+    moments = calculate_moments(cube, rest_wavelength=1402.77 * u.Angstrom, wings=1.0 * u.Angstrom, integrated=True)
+    intensity = moments["intensity"]
+    centroid = moments["centroid"]
+    width = moments["width"]
+    assert intensity.unit == u.DN * u.nm
+    # Intensity value should be the analytic integral
+    expected_intensity = np.sqrt(2 * np.pi) * 10.0 * 0.005
+    assert_quantity_allclose(intensity.data[0, 0] * intensity.unit, expected_intensity * u.DN * u.nm, rtol=0.01)
+    # Centroid and width should be unchanged from the non-integrated case
+    assert_quantity_allclose(centroid.data[0, 0] * centroid.unit, 140.277 * u.nm, atol=0.001 * u.nm)
+    assert_quantity_allclose(width.data[0, 0] * width.unit, 0.005 * u.nm, rtol=0.05)

--- a/irispy/utils/tests/test_moments.py
+++ b/irispy/utils/tests/test_moments.py
@@ -14,7 +14,9 @@ from irispy.utils.moments import calculate_moments
 
 
 def test_calculate_moments_basic(sns_sg_file):
-    """Test that calculate_moments runs on real data and returns correct shapes and units."""
+    """
+    Test that calculate_moments runs on real data and returns correct shapes and units.
+    """
     raster_collection = read_files(sns_sg_file)
     cube = raster_collection["C II 1336"][0]
     rest_wvl = 1332.9 * u.Angstrom
@@ -52,7 +54,9 @@ def test_calculate_moments_basic(sns_sg_file):
 
 
 def test_calculate_moments_sliced_cube(sns_sg_file):
-    """Test that calculate_moments works on a sliced cube and with default arguments."""
+    """
+    Test that calculate_moments works on a sliced cube and with default arguments.
+    """
     raster_collection = read_files(sns_sg_file)
     cube = raster_collection["C II 1336"][0]
     cube_slice = cube[10, :, :]
@@ -64,7 +68,9 @@ def test_calculate_moments_sliced_cube(sns_sg_file):
 
 
 def test_calculate_moments_asymmetric_wings(sns_sg_file):
-    """Test that calculate_moments works with asymmetric wings."""
+    """
+    Test that calculate_moments works with asymmetric wings.
+    """
     raster_collection = read_files(sns_sg_file)
     cube = raster_collection["C II 1336"][0]
     rest_wvl = 1332.9 * u.Angstrom
@@ -80,7 +86,10 @@ def test_calculate_moments_asymmetric_wings(sns_sg_file):
 
 
 def test_calculate_moments_wings_without_rest_wavelength(sns_sg_file):
-    """Test that calculate_moments raises an error when wings is given without rest_wavelength."""
+    """
+    Test that calculate_moments raises an error when wings is given without
+    rest_wavelength.
+    """
     raster_collection = read_files(sns_sg_file)
     cube = raster_collection["C II 1336"][0]
     with pytest.raises(ValueError, match="rest_wavelength must be provided"):
@@ -88,7 +97,9 @@ def test_calculate_moments_wings_without_rest_wavelength(sns_sg_file):
 
 
 def test_calculate_moments_known_gaussian():
-    """Test calculate_moments against a known Gaussian profile."""
+    """
+    Test calculate_moments against a known Gaussian profile.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
     spectrum = gauss(wvls.value)
@@ -116,7 +127,9 @@ def test_calculate_moments_known_gaussian():
 
 @figure_test
 def test_calculate_moments_known_gaussian_figure():
-    """Visual regression test for moment extraction on known Gaussian profiles."""
+    """
+    Visual regression test for moment extraction on known Gaussian profiles.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     rest_wvl = 1402.77 * u.Angstrom
     # Per-row properties: (amplitude, stddev in Å, Doppler shift in km/s)
@@ -181,7 +194,9 @@ def test_calculate_moments_known_gaussian_figure():
 
 
 def test_calculate_moments_negative_values_zeroed():
-    """Test that negative data values are treated as zero during moment calculation."""
+    """
+    Test that negative data values are treated as zero during moment calculation.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     spectrum = np.ones_like(wvls.value) * 10.0
     spectrum[10:20] = -5.0
@@ -202,7 +217,9 @@ def test_calculate_moments_negative_values_zeroed():
 
 
 def test_calculate_moments_nan_values_zeroed():
-    """Test that NaN data values are treated as zero during moment calculation."""
+    """
+    Test that NaN data values are treated as zero during moment calculation.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     spectrum = np.ones_like(wvls.value) * 10.0
     spectrum[10:20] = np.nan
@@ -220,7 +237,9 @@ def test_calculate_moments_nan_values_zeroed():
 
 
 def test_calculate_moments_zero_intensity():
-    """Test that a completely zero spectrum returns NaN centroid and width."""
+    """
+    Test that a completely zero spectrum returns NaN centroid and width.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     spectrum = np.zeros_like(wvls.value)
     data = spectrum.reshape(1, 1, -1)
@@ -235,7 +254,9 @@ def test_calculate_moments_zero_intensity():
 
 
 def test_calculate_moments_vectorized_spatial():
-    """Test that calculate_moments correctly handles different spectra per spatial pixel."""
+    """
+    Test that calculate_moments correctly handles different spectra per spatial pixel.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     # Pixel (0, 0): Gaussian centered at 1402.77
     gauss_0 = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
@@ -259,7 +280,9 @@ def test_calculate_moments_vectorized_spatial():
 
 
 def test_calculate_moments_wings_excludes_outside():
-    """Test that pixels outside the wings window are excluded from the calculation."""
+    """
+    Test that pixels outside the wings window are excluded from the calculation.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     # Create a spectrum with two peaks: one at 1402.77 (the target) and one at 1403.3 (outside wings)
     gauss_target = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
@@ -276,7 +299,9 @@ def test_calculate_moments_wings_excludes_outside():
 
 
 def test_calculate_moments_min_intensity():
-    """Test that min_intensity masks low-signal pixels."""
+    """
+    Test that min_intensity masks low-signal pixels.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
     spectrum = gauss(wvls.value)
@@ -290,7 +315,9 @@ def test_calculate_moments_min_intensity():
 
 
 def test_calculate_moments_wings_empty_window():
-    """Test that an empty wings window raises ValueError."""
+    """
+    Test that an empty wings window raises ValueError.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     spectrum = np.ones_like(wvls.value)
     data = spectrum.reshape(1, 1, -1)
@@ -301,7 +328,9 @@ def test_calculate_moments_wings_empty_window():
 
 
 def test_calculate_moments_saturation_limit():
-    """Test that saturation_limit masks saturated pixels."""
+    """
+    Test that saturation_limit masks saturated pixels.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
     spectrum = gauss(wvls.value)
@@ -316,7 +345,9 @@ def test_calculate_moments_saturation_limit():
 
 
 def test_calculate_moments_integrated():
-    """Test that integrated=True returns intensity in DN·nm."""
+    """
+    Test that integrated=True returns intensity in DN·nm.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
     spectrum = gauss(wvls.value)
@@ -336,7 +367,9 @@ def test_calculate_moments_integrated():
 
 
 def test_calculate_moments_min_intensity_mixed_pixels():
-    """Test that min_intensity only masks pixels below the threshold."""
+    """
+    Test that min_intensity only masks pixels below the threshold.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     # Create a 2x2 spatial grid with different amplitudes
     gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
@@ -364,7 +397,9 @@ def test_calculate_moments_min_intensity_mixed_pixels():
 
 
 def test_calculate_moments_min_intensity_at_threshold():
-    """Test that pixels exactly at min_intensity are NOT masked."""
+    """
+    Test that pixels exactly at min_intensity are NOT masked.
+    """
     wvls = np.linspace(1402.0, 1403.5, 100) * u.Angstrom
     gauss = Gaussian1D(amplitude=10.0, mean=1402.77, stddev=0.05)
     spectrum = gauss(wvls.value)


### PR DESCRIPTION
## Summary by Sourcery

Add utilities and examples for computing spectral moments from IRIS spectrogram cubes and update related documentation, plotting, and tests.

New Features:
- Introduce a `calculate_moments` utility to compute spectral line intensity, centroid, and width (and corresponding velocity diagnostics) from spectrogram cubes.
- Add an analysis example demonstrating how to compute and visualize spectral moments from IRIS raster data.

Enhancements:
- Adjust the spectral fitting example plotting to use a subplot mosaic layout and include the field-of-view context image.
- Extend the docs build Makefile with a custom clean target to remove Sphinx build output and generated artifacts.

Documentation:
- Document the new spectral moments functionality in the gallery and changelog.

Tests:
- Add a comprehensive test suite for spectral moment calculations, including edge cases, vectorization, unit handling, and a figure-based regression test.
- Add a helper to construct minimal test `SpectrogramCube` instances for use in unit tests.

Chores:
- Update stored Matplotlib figure hashes to reflect new plotting outputs.