### PR TITLE
Line density ratio plus example

### DIFF
--- a/changelog/126.feature.rst
+++ b/changelog/126.feature.rst
@@ -1,0 +1,1 @@
+Added utilities to compute IRIS density diagnostics from line ratios, including `~irispy.utils.density.density_diagnostic` and `~irispy.utils.density.map_ratio_to_quantity`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,7 @@ intersphinx_mapping = {
     "aiapy": ("https://aiapy.readthedocs.io/en/latest/", None),
     "astropy": ("https://docs.astropy.org/en/latest/", None),
     "astroscrappy": ("https://astroscrappy.readthedocs.io/en/latest/", None),
+    "fiasco": ("https://fiasco.readthedocs.io/en/latest/", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     "mpl_animators": ("https://docs.sunpy.org/projects/mpl-animators/en/latest/", None),
     "ndcube": ("https://docs.sunpy.org/projects/ndcube/en/latest/", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,12 +4,17 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import os
+import configparser
 import datetime
+import os
 from pathlib import Path
+from shutil import copyfile
+
 from packaging.version import Version
 
-# -- Read the Docs Specific Configuration --------------------------------------
+DOCS_DIR = Path(__file__).resolve().parent
+
+# -- Read the Docs Specific Configuration -------------------------------------
 
 # This needs to be done before anything is imported
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
@@ -20,7 +25,7 @@ if on_rtd:
     os.environ["LC_ALL"] = "C"
     os.environ["PARFIVE_HIDE_PROGRESS"] = "True"
 
-# -- Project information -----------------------------------------------------
+# -- Project information ------------------------------------------------------
 
 # The full version, including alpha/beta/rc tags
 from irispy import __version__
@@ -40,7 +45,7 @@ project = "irispy"
 author = "IRIS Instrument Team @ LMSAL"
 copyright = f"{datetime.datetime.now(datetime.UTC).year}, {author}"  # NOQA: A001
 
-# -- General configuration ---------------------------------------------------
+# -- General configuration ----------------------------------------------------
 
 import warnings
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -107,7 +112,7 @@ default_role = "py:obj"
 nitpicky = True
 # This is not used. See docs/nitpick-exceptions file for the actual listing.
 nitpick_ignore = []
-with Path("nitpick-exceptions").open() as nitpick_exceptions:
+with (DOCS_DIR / "nitpick-exceptions").open() as nitpick_exceptions:
     for line in nitpick_exceptions:
         if line.strip() == "" or line.startswith("#"):
             continue
@@ -115,7 +120,7 @@ with Path("nitpick-exceptions").open() as nitpick_exceptions:
         target = target.strip()
         nitpick_ignore.append((dtype, target))
 
-# -- Options for intersphinx extension ---------------------------------------
+# -- Options for intersphinx extension ----------------------------------------
 intersphinx_mapping = {
     "aiapy": ("https://aiapy.readthedocs.io/en/latest/", None),
     "astropy": ("https://docs.astropy.org/en/latest/", None),
@@ -146,7 +151,7 @@ ogp_custom_meta_tags = ('<meta property="og:ignore_canonical" content="true" />'
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
 copybutton_prompt_is_regexp = True
 
-# -- Options for HTML output -------------------------------------------------
+# -- Options for HTML output --------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -180,7 +185,7 @@ graphviz_dot_args = [
 # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autoclass_content
 autoclass_content = "both"
 
-# -- Other options ----------------------------------------------------------
+# -- Other options ------------------------------------------------------------
 
 # Configuration for sphinx-gallery
 from sunpy_sphinx_theme import PNG_ICON
@@ -231,7 +236,34 @@ def jinja_to_rst(app, docname, source):
             source[0] = source[0].replace(to_replace, "")
 
 
-# -- Sphinx setup --------------------------------------------------------------
+# -- Database on RTD or CI ----------------------------------------------------
+on_gha = os.environ.get("CI") == "true"
+
+if on_rtd or on_gha:
+    from astropy.utils.data import download_file
+
+    fiasco_home = Path.home() / ".fiasco"
+    ascii_dbase_root = fiasco_home / "chianti_dbase"
+    hdf5_dbase_root = fiasco_home / "chianti_dbase.h5"
+    fiasco_rc = fiasco_home / "fiascorc"
+
+    fiasco_home.mkdir(exist_ok=True, parents=True)
+    ascii_dbase_root.mkdir(exist_ok=True, parents=True)
+
+    config = configparser.ConfigParser()
+    config.add_section("database")
+    config.set("database", "ascii_dbase_root", str(ascii_dbase_root))
+    config.set("database", "hdf5_dbase_root", str(hdf5_dbase_root))
+    with fiasco_rc.open(mode="w") as fd:
+        config.write(fd)
+
+    if not hdf5_dbase_root.is_file():
+        database_url = "https://github.com/LM-SAL/data/raw/refs/heads/main/chianti_dbase.h5"
+        downloaded_database = download_file(database_url, cache=True, show_progress=True)
+        copyfile(downloaded_database, hdf5_dbase_root)
+
+
+# -- Sphinx setup -------------------------------------------------------------
 
 
 def setup(app):

--- a/docs/reference/utils.rst
+++ b/docs/reference/utils.rst
@@ -10,6 +10,8 @@ The `irispy.utils` module provides functions useful for ``irispy`` users or deve
 
 .. automodapi:: irispy.utils.cosmic_rays
 
+.. automodapi:: irispy.utils.density
+
 .. automodapi:: irispy.utils.dust
 
 .. automodapi:: irispy.utils.moments

--- a/examples/analysis/05_red_blue_asymmetry.py
+++ b/examples/analysis/05_red_blue_asymmetry.py
@@ -104,7 +104,15 @@ ax = axes[0]
 rba_map = np.where(quality.data == 0, asymmetry.data, np.nan)
 vmax = max(np.nanpercentile(np.abs(rba_map), 98), 0.15)
 im = ax.imshow(rba_map, cmap="RdBu_r", origin="lower", aspect="auto", vmin=-vmax, vmax=vmax)
-ax.plot(selected_pixel_index[1], selected_pixel_index[0], "k+", markersize=16, transform=ax.get_transform("pixel"))
+ax.plot(
+    selected_pixel_index[1],
+    selected_pixel_index[0],
+    color="lime",
+    marker="+",
+    linestyle="none",
+    markersize=16,
+    transform=ax.get_transform("pixel"),
+)
 ax.coords[0].set_axislabel("Helioprojective Latitude [arcsec]")
 ax.coords[1].set_axislabel("Helioprojective Longitude [arcsec]")
 fig.colorbar(im, ax=ax, shrink=0.8, label="Red-Blue Asymmetry")

--- a/examples/analysis/06_oiv_density_diagnostics.py
+++ b/examples/analysis/06_oiv_density_diagnostics.py
@@ -1,0 +1,114 @@
+"""
+==============================
+O IV Density-Diagnostic Curves
+==============================
+
+The goal of this example is to show how to compute and plot density-sensitive
+O IV line ratios with `~irispy.utils.density.density_diagnostic`.
+These ratios are sensitive to the electron density in the solar atmosphere, and
+they are often used to diagnose conditions in the solar transition region.
+
+.. warning::
+
+    This example requires the optional density dependencies, including a version
+    of `fiasco` that provides ``fiasco.line_ratio_density``.
+"""
+
+import fiasco
+import matplotlib.pyplot as plt
+import numpy as np
+
+import astropy.units as u
+
+from irispy.utils.density import density_diagnostic
+
+###############################################################################
+# We will reproduce aspects of the top row of Fig. 4 from
+# `Dudik et al. (2014) <https://doi.org/10.1088/2041-8205/780/1/L12>`__, which shows the O IV line
+# ratios as a function of electron density for three different Maxwellian temperatures.
+
+density = np.logspace(9, 12, 20) * u.cm**-3
+temperature_samples = 10 ** np.array([4.80, 5.15, 5.50]) * u.K
+line_styles = [":", "-", "--"]
+temperature_labels = ["4.80", "5.15", "5.50"]
+o4_models = []
+for temperature, line_style, label in zip(
+    temperature_samples,
+    line_styles,
+    temperature_labels,
+    strict=True,
+):
+    ion = fiasco.Ion("O IV", np.array([temperature.to_value("K")]) * u.K, ask_before=False)
+    o4_models.append((line_style, label, ion))
+
+ratio_definitions = [
+    ("O IV 1401.16 / 1404.78Å", 1401.157 * u.angstrom, 1404.806 * u.angstrom),
+    ("O IV 1404.78 / 1399.77Å", 1404.806 * u.angstrom, 1399.780 * u.angstrom),
+]
+
+###############################################################################
+# The exact curve values will differ somewhat from the paper because this example
+# uses the current CHIANTI database through `fiasco` rather than the CHIANTI
+# version used by Dudik et al. (2014).
+
+# `~irispy.utils.density.density_diagnostic` needs measured line intensities as
+# input because it maps an observed ratio back to density. To plot the diagnostic
+# curves, we first use unit intensities and then use one point on the returned
+# curve as a synthetic observation.
+
+fig, axes = plt.subplots(
+    ncols=2,
+    figsize=(11, 4.2),
+    constrained_layout=True,
+    sharex=True,
+)
+
+line_ratio_density_kwargs = {"use_two_ion_model": False}
+for ax, (title, numerator, denominator) in zip(axes, ratio_definitions, strict=True):
+    for line_style, label, ion in o4_models:
+        diagnostic = density_diagnostic(
+            1 * u.ct,
+            1 * u.ct,
+            density,
+            ion=ion,
+            numerator=numerator,
+            denominator=denominator,
+            temperature=ion.temperature,
+            line_ratio_density_kwargs=line_ratio_density_kwargs,
+        )
+        ax.plot(
+            np.log10(diagnostic["density_grid"].to_value("cm-3")),
+            diagnostic["theoretical_ratio"].value,
+            color="black",
+            linestyle=line_style,
+            linewidth=1.8,
+            label=label,
+        )
+        if label == "5.15":
+            sample_index = diagnostic["density_grid"].size // 2
+            sample_ratio = diagnostic["theoretical_ratio"][sample_index]
+            observed = density_diagnostic(
+                sample_ratio.value * 100 * u.ct,
+                100 * u.ct,
+                density,
+                ion=ion,
+                numerator=numerator,
+                denominator=denominator,
+                temperature=ion.temperature,
+                line_ratio_density_kwargs=line_ratio_density_kwargs,
+            )
+            ax.plot(
+                np.log10(observed["density"].to_value("cm-3")),
+                observed["ratio"].value,
+                color="tab:red",
+                marker="o",
+                linestyle="none",
+                label="synthetic observation" if ax is axes[0] else None,
+            )
+    ax.set_title("Density diagnostics")
+    ax.set_xlabel(r"$\log(n_e / \mathrm{cm^{-3}})$")
+    ax.set_ylabel(title)
+
+axes[0].legend(loc="upper left", title=r"$\log(T / \mathrm{K})$")
+
+plt.show()

--- a/irispy/utils/__init__.py
+++ b/irispy/utils/__init__.py
@@ -1,5 +1,6 @@
 from . import constants as constants
 from . import cosmic_rays as cosmic_rays
+from . import density as density
 from . import dust as dust
 from . import moments as moments
 from . import red_blue as red_blue

--- a/irispy/utils/density.py
+++ b/irispy/utils/density.py
@@ -1,0 +1,311 @@
+"""
+Helpers for IRIS density diagnostics.
+"""
+
+from importlib import import_module
+
+import numpy as np
+from scipy.interpolate import interp1d
+
+import astropy.units as u
+
+__all__ = ["density_diagnostic", "map_ratio_to_quantity"]
+
+
+def map_ratio_to_quantity(observed_ratio, quantity, theoretical_ratio, *, bounds_error=False, fill_value=np.nan):
+    """
+    Map an observed line ratio to the associated physical quantity.
+
+    Parameters
+    ----------
+    observed_ratio : array-like or `~astropy.units.Quantity`
+        Observed line ratio values. Must be dimensionless.
+    quantity : `~astropy.units.Quantity`
+        Quantity grid associated with ``theoretical_ratio``, e.g. an electron
+        density grid.
+    theoretical_ratio : array-like or `~astropy.units.Quantity`
+        Theoretical line ratio sampled on ``quantity``. Must be dimensionless
+        and monotonic.
+    bounds_error : `bool`, optional
+        If `True`, raise an exception when ``observed_ratio`` falls outside the
+        theoretical ratio range. By default, points outside the range are set by
+        ``fill_value``.
+    fill_value : scalar, tuple, or `~astropy.units.Quantity`, optional
+        Value used outside of the interpolation interval. If a quantity is
+        given, it must be convertible to the units of ``quantity``.
+    """
+    observed_ratio = u.Quantity(observed_ratio, u.dimensionless_unscaled)
+    quantity = np.ravel(u.Quantity(quantity))
+    theoretical_ratio = np.ravel(u.Quantity(theoretical_ratio, u.dimensionless_unscaled).value)
+
+    if quantity.shape != theoretical_ratio.shape:
+        msg = "quantity and theoretical_ratio must have the same shape."
+        raise ValueError(msg)
+
+    finite = np.isfinite(quantity.value) & np.isfinite(theoretical_ratio)
+    quantity = quantity[finite]
+    theoretical_ratio = theoretical_ratio[finite]
+
+    if quantity.size < 2:
+        msg = "At least two finite samples are required to interpolate a ratio curve."
+        raise ValueError(msg)
+
+    diff = np.diff(theoretical_ratio)
+    nonzero = diff != 0.0
+    if not np.any(nonzero):
+        msg = "theoretical_ratio must vary over the provided quantity grid."
+        raise ValueError(msg)
+    if np.all(diff[nonzero] < 0.0):
+        quantity = quantity[::-1]
+        theoretical_ratio = theoretical_ratio[::-1]
+    elif not np.all(diff[nonzero] > 0.0):
+        msg = (
+            "theoretical_ratio must be monotonic to map ratios back to a quantity. "
+            "Restrict the grid to a monotonic interval first."
+        )
+        raise ValueError(msg)
+
+    theoretical_ratio, unique_index = np.unique(theoretical_ratio, return_index=True)
+    quantity = quantity[unique_index]
+    if quantity.size < 2:
+        msg = "Theoretical ratio must contain at least two unique samples."
+        raise ValueError(msg)
+
+    if isinstance(fill_value, tuple):
+        fill_value = tuple(
+            value.to_value(quantity.unit) if isinstance(value, u.Quantity) else value for value in fill_value
+        )
+    elif isinstance(fill_value, u.Quantity):
+        fill_value = fill_value.to_value(quantity.unit)
+
+    interp = interp1d(
+        theoretical_ratio,
+        quantity.value,
+        bounds_error=bounds_error,
+        fill_value=fill_value,
+    )
+    return u.Quantity(interp(observed_ratio.to_value(u.dimensionless_unscaled)), quantity.unit)
+
+
+def density_diagnostic(
+    intensity_numerator,
+    intensity_denominator,
+    density_grid,
+    *,
+    ion,
+    numerator,
+    denominator,
+    intensity_numerator_uncertainty=None,
+    intensity_denominator_uncertainty=None,
+    temperature=None,
+    bounds_error=False,
+    fill_value=np.nan,
+    line_ratio_density_kwargs=None,
+):
+    """
+    Map an observed IRIS line ratio onto a theoretical density curve.
+
+    Parameters
+    ----------
+    intensity_numerator, intensity_denominator : array-like or `~astropy.units.Quantity`
+        Measured integrated intensities for the numerator and denominator lines.
+    density_grid : `~astropy.units.Quantity`
+        Density grid on which to evaluate the theoretical ratio curve.
+    ion : `fiasco.Ion`
+        Ion used to compute the theoretical ratio curve.
+    numerator, denominator : `~astropy.units.Quantity`
+        Required wavelengths of the numerator and denominator transitions.
+    intensity_numerator_uncertainty, intensity_denominator_uncertainty :
+        array-like or `~astropy.units.Quantity`, optional
+        Uncertainties on the measured integrated intensities.
+    temperature : `~astropy.units.Quantity`, optional
+        Temperature at which to evaluate the theoretical ratio curve from
+        ``ion``. If omitted and scalar, uses the ion temperature; if omitted
+        and non-scalar, falls back to ``ion.formation_temperature``.
+    bounds_error : `bool`, optional
+        Passed through to `map_ratio_to_quantity`.
+    fill_value : scalar or `~astropy.units.Quantity`, optional
+        Passed through to `map_ratio_to_quantity`.
+    line_ratio_density_kwargs : `dict`, optional
+        Extra keyword arguments forwarded to ``fiasco.line_ratio_density``.
+    """
+    if (intensity_numerator_uncertainty is None) != (intensity_denominator_uncertainty is None):
+        msg = "Both numerator and denominator uncertainties must be provided together."
+        raise ValueError(msg)
+    if any(value is None for value in (ion, numerator, denominator)):
+        msg = "ion, numerator, and denominator are required."
+        raise ValueError(msg)
+
+    try:
+        fiasco = import_module("fiasco")
+    except ImportError as exc:
+        msg = "IRIS density diagnostics require the optional dependency 'fiasco'."
+        raise ImportError(msg) from exc
+
+    if line_ratio_density_kwargs is None:
+        line_ratio_density_kwargs = {}
+
+    intensity_numerator = u.Quantity(intensity_numerator)
+    intensity_denominator = u.Quantity(intensity_denominator)
+    numerator_value, denominator_value = np.broadcast_arrays(intensity_numerator.value, intensity_denominator.value)
+    ratio_value = np.divide(
+        numerator_value,
+        denominator_value,
+        out=np.full(numerator_value.shape, np.nan),
+        where=denominator_value != 0.0,
+    )
+    ratio = u.Quantity(ratio_value, intensity_numerator.unit / intensity_denominator.unit).to(u.dimensionless_unscaled)
+
+    ratio_uncertainty = None
+    if intensity_numerator_uncertainty is not None:
+        numerator_uncertainty = u.Quantity(intensity_numerator_uncertainty)
+        denominator_uncertainty = u.Quantity(intensity_denominator_uncertainty)
+        numerator_uncertainty_value, numerator_value = np.broadcast_arrays(
+            numerator_uncertainty.to_value(intensity_numerator.unit),
+            intensity_numerator.value,
+        )
+        denominator_uncertainty_value, denominator_value = np.broadcast_arrays(
+            denominator_uncertainty.to_value(intensity_denominator.unit),
+            intensity_denominator.value,
+        )
+        numerator_fraction = np.divide(
+            numerator_uncertainty_value,
+            numerator_value,
+            out=np.full(numerator_uncertainty_value.shape, np.nan),
+            where=numerator_value != 0.0,
+        )
+        denominator_fraction = np.divide(
+            denominator_uncertainty_value,
+            denominator_value,
+            out=np.full(denominator_uncertainty_value.shape, np.nan),
+            where=denominator_value != 0.0,
+        )
+        ratio_uncertainty = np.abs(ratio) * np.sqrt(numerator_fraction**2 + denominator_fraction**2)
+        try:
+            ratio_uncertainty = np.broadcast_to(ratio_uncertainty.value, ratio.shape)
+        except ValueError as exc:
+            msg = (
+                f"Uncertainty shapes {numerator_uncertainty.shape} and {denominator_uncertainty.shape} "
+                f"are not broadcastable to intensity shape {ratio.shape}."
+            )
+            raise ValueError(msg) from exc
+        ratio_uncertainty = u.Quantity(ratio_uncertainty, ratio.unit)
+
+    theoretical_ratio = fiasco.line_ratio_density(
+        ion,
+        numerator,
+        denominator,
+        density_grid,
+        **line_ratio_density_kwargs,
+    )
+    theoretical_ratio = u.Quantity(theoretical_ratio, u.dimensionless_unscaled).squeeze()
+    if theoretical_ratio.ndim > 1:
+        ion_temperature = u.Quantity(ion.temperature)
+        if theoretical_ratio.shape[0] != ion_temperature.size:
+            msg = "theoretical_ratio temperature axis does not match ion.temperature"
+            raise ValueError(msg)
+
+        if temperature is None:
+            ratio_temperature = u.Quantity(ion.temperature)
+            if ratio_temperature.size != 1:
+                ratio_temperature = u.Quantity(ion.formation_temperature)
+        else:
+            ratio_temperature = u.Quantity(temperature)
+        if ratio_temperature.size == 1:
+            ratio_temperature = ratio_temperature.flat[0]
+
+        order = np.argsort(ion_temperature.to_value(u.K))
+        temperature_grid = ion_temperature.to_value(u.K)[order]
+        ratio_values = theoretical_ratio.value[order]
+        interp = interp1d(temperature_grid, ratio_values, axis=0, bounds_error=False, fill_value=np.nan)
+        theoretical_ratio = u.Quantity(interp(ratio_temperature.to_value(u.K)), theoretical_ratio.unit).squeeze()
+
+    density_grid = u.Quantity(density_grid)
+    theoretical_ratio = u.Quantity(theoretical_ratio, u.dimensionless_unscaled)
+    finite = np.isfinite(density_grid.value) & np.isfinite(theoretical_ratio.value)
+    density_grid = density_grid[finite]
+    theoretical_ratio = theoretical_ratio[finite]
+
+    segments = []
+    if density_grid.size < 2:
+        segments.append((density_grid, theoretical_ratio))
+    else:
+        start = 0
+        previous_sign = None
+        for i, delta in enumerate(np.diff(theoretical_ratio.value)):
+            sign = np.sign(delta)
+            if sign == 0:
+                continue
+            if previous_sign is None:
+                previous_sign = sign
+                continue
+            if sign != previous_sign:
+                segments.append((density_grid[start : i + 1], theoretical_ratio[start : i + 1]))
+                start = i
+                previous_sign = sign
+        segments.append((density_grid[start:], theoretical_ratio[start:]))
+        segments = [(quantity, ratio_segment) for quantity, ratio_segment in segments if quantity.size >= 2]
+    if len(segments) == 1:
+        density_grid, theoretical_ratio = segments[0]
+    elif segments:
+        observed_ratio = ratio.value[np.isfinite(ratio.value)]
+        if ratio_uncertainty is not None:
+            ratio_min_obs = (ratio - ratio_uncertainty).value[np.isfinite((ratio - ratio_uncertainty).value)]
+            ratio_max_obs = (ratio + ratio_uncertainty).value[np.isfinite((ratio + ratio_uncertainty).value)]
+            observed_ratio_range = np.concatenate([ratio_min_obs, ratio_max_obs])
+        else:
+            observed_ratio_range = observed_ratio
+        best_score = None
+        for segment in segments:
+            quantity, ratio_segment = segment
+            ratio_min = np.nanmin(ratio_segment.value)
+            ratio_max = np.nanmax(ratio_segment.value)
+            in_range = np.logical_and(observed_ratio_range >= ratio_min, observed_ratio_range <= ratio_max).sum()
+            score = (in_range, quantity.size, ratio_max - ratio_min)
+            if best_score is None or score > best_score:
+                density_grid, theoretical_ratio = segment
+                best_score = score
+
+    density = map_ratio_to_quantity(
+        ratio,
+        density_grid,
+        theoretical_ratio,
+        bounds_error=bounds_error,
+        fill_value=fill_value,
+    )
+
+    density_lower = None
+    density_upper = None
+    if ratio_uncertainty is not None:
+        density_minus = map_ratio_to_quantity(
+            ratio - ratio_uncertainty,
+            density_grid,
+            theoretical_ratio,
+            bounds_error=bounds_error,
+            fill_value=fill_value,
+        )
+        density_plus = map_ratio_to_quantity(
+            ratio + ratio_uncertainty,
+            density_grid,
+            theoretical_ratio,
+            bounds_error=bounds_error,
+            fill_value=fill_value,
+        )
+        density_lower = u.Quantity(
+            np.fmin(density_minus.to_value(density.unit), density_plus.to_value(density.unit)),
+            density.unit,
+        )
+        density_upper = u.Quantity(
+            np.fmax(density_minus.to_value(density.unit), density_plus.to_value(density.unit)),
+            density.unit,
+        )
+
+    return {
+        "ratio": ratio,
+        "ratio_uncertainty": ratio_uncertainty,
+        "density": density,
+        "density_lower": density_lower,
+        "density_upper": density_upper,
+        "density_grid": u.Quantity(density_grid),
+        "theoretical_ratio": u.Quantity(theoretical_ratio, u.dimensionless_unscaled),
+    }

--- a/irispy/utils/tests/test_density.py
+++ b/irispy/utils/tests/test_density.py
@@ -1,0 +1,230 @@
+import sys
+import types
+
+import numpy as np
+import pytest
+
+import astropy.units as u
+
+from irispy.utils.density import density_diagnostic, map_ratio_to_quantity
+
+
+def _install_fake_fiasco(monkeypatch, ratio):
+    calls = {}
+
+    def line_ratio_density(ion, numerator, denominator, density_grid, **kwargs):
+        calls["ion"] = ion
+        calls["numerator"] = numerator
+        calls["denominator"] = denominator
+        calls["density_grid"] = density_grid
+        calls["line_ratio_density_kwargs"] = kwargs
+        return u.Quantity(ratio, u.dimensionless_unscaled)
+
+    fake_fiasco = types.SimpleNamespace(line_ratio_density=line_ratio_density)
+    monkeypatch.setitem(sys.modules, "fiasco", fake_fiasco)
+    return calls
+
+
+def test_map_ratio_to_quantity():
+    density = [1e8, 1e9, 1e10] * u.cm**-3
+    theoretical_ratio = [0.2, 0.5, 0.8] * u.dimensionless_unscaled
+
+    mapped_density = map_ratio_to_quantity([0.2, 0.65, 1.0], density, theoretical_ratio)
+
+    assert mapped_density.unit == density.unit
+    assert mapped_density.shape == (3,)
+    assert u.allclose(mapped_density[:2], [1e8, 5.5e9] * u.cm**-3)
+    assert np.isnan(mapped_density[-1].value)
+
+
+def test_map_ratio_to_quantity_decreasing_curve():
+    density = [1e8, 1e9, 1e10] * u.cm**-3
+    theoretical_ratio = [0.8, 0.5, 0.2] * u.dimensionless_unscaled
+
+    assert u.allclose(map_ratio_to_quantity(0.35, density, theoretical_ratio), 5.5e9 * u.cm**-3)
+
+
+def test_map_ratio_to_quantity_rejects_non_monotonic_curve():
+    density = [1e8, 1e9, 1e10] * u.cm**-3
+    theoretical_ratio = [0.2, 0.8, 0.5] * u.dimensionless_unscaled
+
+    with pytest.raises(ValueError, match="must be monotonic"):
+        map_ratio_to_quantity(0.35, density, theoretical_ratio)
+
+
+def test_density_diagnostic(monkeypatch):
+    _install_fake_fiasco(monkeypatch, [0.5, 1.0])
+    fake_ion = types.SimpleNamespace(
+        temperature=[1e5, 2e5] * u.K,
+        formation_temperature=2e5 * u.K,
+    )
+
+    result = density_diagnostic(
+        [1.0, 1.5] * u.ct,
+        [2.0, 2.0] * u.ct,
+        [1e10, 1e11] * u.cm**-3,
+        ion=fake_ion,
+        numerator=1399.78 * u.angstrom,
+        denominator=1401.16 * u.angstrom,
+        intensity_numerator_uncertainty=[0.1, 0.1] * u.ct,
+        intensity_denominator_uncertainty=[0.2, 0.2] * u.ct,
+    )
+
+    np.testing.assert_allclose(result["ratio"].value, [0.5, 0.75])
+    assert result["ratio_uncertainty"] is not None
+    assert result["density_lower"] is not None
+    assert result["density_upper"] is not None
+    assert u.allclose(result["density"], [1e10, 5.5e10] * u.cm**-3)
+
+
+def test_density_diagnostic_builds_theoretical_ratio_with_fiasco(monkeypatch):
+    calls = _install_fake_fiasco(
+        monkeypatch,
+        [
+            [0.1, 0.2, 0.3],
+            [0.2, 0.4, 0.6],
+            [0.3, 0.6, 0.9],
+        ],
+    )
+    fake_ion = types.SimpleNamespace(
+        temperature=[1e5, 2e5, 3e5] * u.K,
+        formation_temperature=2e5 * u.K,
+    )
+    density_grid = [1, 2, 3] * u.cm**-3
+
+    result = density_diagnostic(
+        [0.4],
+        [1.0],
+        density_grid,
+        ion=fake_ion,
+        numerator=1399.78 * u.angstrom,
+        denominator=1401.16 * u.angstrom,
+        line_ratio_density_kwargs={"use_two_ion_model": False},
+    )
+
+    assert calls["ion"] is fake_ion
+    assert u.allclose(calls["density_grid"], density_grid)
+    assert calls["line_ratio_density_kwargs"] == {"use_two_ion_model": False}
+    np.testing.assert_allclose(result["theoretical_ratio"].value, [0.2, 0.4, 0.6])
+    assert u.allclose(result["density"], [2] * u.cm**-3)
+
+
+def test_density_diagnostic_requires_ion():
+    with pytest.raises(ValueError, match="ion, numerator, and denominator are required"):
+        density_diagnostic(
+            [4, 8] * u.ct,
+            [2, 4] * u.ct,
+            [1e10, 1e11] * u.cm**-3,
+            ion=None,
+            numerator=1399.78 * u.angstrom,
+            denominator=1401.16 * u.angstrom,
+        )
+
+
+def test_density_diagnostic_selects_monotonic_branch(monkeypatch):
+    _install_fake_fiasco(monkeypatch, [0.1, 0.2, 0.3, 0.25, 0.2])
+    fake_ion = types.SimpleNamespace(
+        temperature=[1e5, 2e5] * u.K,
+        formation_temperature=2e5 * u.K,
+    )
+
+    result = density_diagnostic(
+        [2.4, 2.8],
+        [10.0, 10.0],
+        density_grid=[1, 2, 3, 4, 5] * u.cm**-3,
+        ion=fake_ion,
+        numerator=1399.78 * u.angstrom,
+        denominator=1401.16 * u.angstrom,
+    )
+
+    np.testing.assert_allclose(result["theoretical_ratio"].value, [0.1, 0.2, 0.3])
+    np.testing.assert_allclose(result["density_grid"].value, [1, 2, 3])
+
+
+def test_density_diagnostic_zero_denominator(monkeypatch):
+    _install_fake_fiasco(monkeypatch, [0.5, 1.0])
+    fake_ion = types.SimpleNamespace(
+        temperature=[1e5, 2e5] * u.K,
+        formation_temperature=2e5 * u.K,
+    )
+
+    result = density_diagnostic(
+        [1.0, 1.5] * u.ct,
+        [2.0, 0.0] * u.ct,
+        [1e10, 1e11] * u.cm**-3,
+        ion=fake_ion,
+        numerator=1399.78 * u.angstrom,
+        denominator=1401.16 * u.angstrom,
+    )
+
+    np.testing.assert_allclose(result["ratio"].value, [0.5, np.nan])
+    assert result["ratio_uncertainty"] is None
+    assert result["density_lower"] is None
+    assert result["density_upper"] is None
+
+
+def test_density_diagnostic_partial_uncertainty_raises():
+    with pytest.raises(ValueError, match="Both numerator and denominator uncertainties"):
+        density_diagnostic(
+            [4, 8] * u.ct,
+            [2, 4] * u.ct,
+            [1e10, 1e11] * u.cm**-3,
+            ion=types.SimpleNamespace(),
+            numerator=1399.78 * u.angstrom,
+            denominator=1401.16 * u.angstrom,
+            intensity_numerator_uncertainty=[0.1, 0.1] * u.ct,
+        )
+
+
+def test_density_diagnostic_explicit_temperature(monkeypatch):
+    """
+    Regression: explicit scalar temperature must not be clobbered by
+    formation_temperature.
+    """
+    _install_fake_fiasco(
+        monkeypatch,
+        [
+            [0.1, 0.2, 0.3],
+            [0.2, 0.4, 0.6],
+            [0.3, 0.6, 0.9],
+        ],
+    )
+    fake_ion = types.SimpleNamespace(
+        temperature=[1e5, 2e5, 3e5] * u.K,
+        formation_temperature=1e5 * u.K,
+    )
+    density_grid = [1, 2, 3] * u.cm**-3
+
+    result = density_diagnostic(
+        [0.4],
+        [1.0],
+        density_grid,
+        ion=fake_ion,
+        numerator=1399.78 * u.angstrom,
+        denominator=1401.16 * u.angstrom,
+        temperature=2e5 * u.K,
+    )
+
+    # If temperature=2e5 K were ignored, the fallback formation temperature
+    # would use the first row and return density=1.
+    assert u.allclose(result["density"], [2] * u.cm**-3)
+
+
+def test_density_diagnostic_uncertainty_shape_mismatch(monkeypatch):
+    _install_fake_fiasco(monkeypatch, [0.5, 1.0])
+    fake_ion = types.SimpleNamespace(
+        temperature=[1e5, 2e5] * u.K,
+        formation_temperature=2e5 * u.K,
+    )
+
+    with pytest.raises(ValueError, match="Uncertainty shapes"):
+        density_diagnostic(
+            [1.0, 1.5] * u.ct,
+            [2.0, 2.0] * u.ct,
+            [1e10, 1e11] * u.cm**-3,
+            ion=fake_ion,
+            numerator=1399.78 * u.angstrom,
+            denominator=1401.16 * u.angstrom,
+            intensity_numerator_uncertainty=[[0.1], [0.1]] * u.ct,
+            intensity_denominator_uncertainty=[[0.2], [0.2]] * u.ct,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,23 +42,31 @@ dependencies = [
   "sunraster>=0.7.0",
 ]
 
-optional-dependencies.all = [ "irispy-lmsal" ]
+optional-dependencies.all = [
+  "irispy-lmsal[cosmic-rays,density]",
+]
 optional-dependencies.cosmic-rays = [
   "astroscrappy",
   "rsliding",
 ]
-optional-dependencies.dev = [ "irispy-lmsal[cosmic-rays,docs,tests]" ]
+optional-dependencies.density = [
+  # TODO: Switch to PyPI release once fiasco.line_ratio_density is released.
+  "fiasco @ git+https://github.com/nabobalis/fiasco.git@ratio-feature",
+]
+optional-dependencies.dev = [
+  "irispy-lmsal[all,docs,tests]",
+]
 optional-dependencies.docs = [
+  "irispy-lmsal[all]",
   "aiapy",
   "dask[distributed]",
-  "irispy-lmsal[cosmic-rays]",
   "pooch",
-  "sphinx",
   "sphinx-automodapi",
   "sphinx-changelog",
   "sphinx-copybutton",
   "sphinx-design",
   "sphinx-gallery",
+  "sphinx",
   "sunkit-image",
   "sunpy-sphinx-theme",
 ]


### PR DESCRIPTION
## Summary by Sourcery

Add utilities for IRIS density diagnostics based on line ratios, expose them via optional dependencies, and document/example their usage.

New Features:
- Introduce utilities to map observed line ratios onto physical quantities and compute IRIS density diagnostics, including uncertainty propagation.
- Add an example script demonstrating O IV density-diagnostic curves using the new line-ratio density functionality.

Enhancements:
- Expose a new optional density extra and include it in the aggregated optional dependencies.
- Improve an existing red–blue asymmetry example by making the selected pixel marker more visually distinct.
- Extend Sphinx intersphinx mappings to link to the fiasco documentation.

Tests:
- Add unit tests covering the new density diagnostic utilities and their interaction with fiasco.