### PR TITLE
Code base review via GPT

### DIFF
--- a/changelog/129.bugfix.rst
+++ b/changelog/129.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed several edge cases in SJI and spectrograph coordinate preservation, bad-pixel masking, density diagnostics, spectral moments, dust masking, and red-blue asymmetry memory usage.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,9 +239,41 @@ def jinja_to_rst(app, docname, source):
 # -- Database on RTD or CI ----------------------------------------------------
 on_gha = os.environ.get("CI") == "true"
 
-if on_rtd or on_gha:
-    from astropy.utils.data import download_file
 
+def _is_not_fiasco_database_version_warning(record):
+    message = record.getMessage()
+    return not (
+        record.name.startswith("fiasco")
+        and "was produced with an earlier version of fiasco" in message
+        and "You may need to rebuild the HDF5 database" in message
+    )
+
+
+def _ensure_hdf5_database(database_url, destination):
+    from astropy.utils.data import download_file  # noqa: PLC0415
+
+    import h5py  # noqa: PLC0415
+
+    if destination.is_file():
+        try:
+            with h5py.File(destination, "r"):
+                return
+        except OSError:
+            pass
+
+    downloaded_database = download_file(database_url, cache=True, show_progress=True)
+    tmp_destination = destination.with_name(f"{destination.name}.tmp")
+    copyfile(downloaded_database, tmp_destination)
+    try:
+        with h5py.File(tmp_destination, "r"):
+            pass
+    except OSError:
+        tmp_destination.unlink(missing_ok=True)
+        raise
+    tmp_destination.replace(destination)
+
+
+if on_rtd or on_gha:
     fiasco_home = Path.home() / ".fiasco"
     ascii_dbase_root = fiasco_home / "chianti_dbase"
     hdf5_dbase_root = fiasco_home / "chianti_dbase.h5"
@@ -257,10 +289,17 @@ if on_rtd or on_gha:
     with fiasco_rc.open(mode="w") as fd:
         config.write(fd)
 
-    if not hdf5_dbase_root.is_file():
-        database_url = "https://github.com/LM-SAL/data/raw/refs/heads/main/chianti_dbase.h5"
-        downloaded_database = download_file(database_url, cache=True, show_progress=True)
-        copyfile(downloaded_database, hdf5_dbase_root)
+    _ensure_hdf5_database(
+        "https://github.com/LM-SAL/data/raw/refs/heads/main/chianti_dbase.h5",
+        hdf5_dbase_root,
+    )
+
+try:
+    import fiasco
+except ImportError:
+    pass
+else:
+    fiasco.log.addFilter(_is_not_fiasco_database_version_warning)
 
 
 # -- Sphinx setup -------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@
 
 import configparser
 import datetime
+import logging
 import os
 from pathlib import Path
 from shutil import copyfile
@@ -240,13 +241,14 @@ def jinja_to_rst(app, docname, source):
 on_gha = os.environ.get("CI") == "true"
 
 
-def _is_not_fiasco_database_version_warning(record):
-    message = record.getMessage()
-    return not (
-        record.name.startswith("fiasco")
-        and "was produced with an earlier version of fiasco" in message
-        and "You may need to rebuild the HDF5 database" in message
-    )
+class _FiascoDatabaseVersionFilter(logging.Filter):
+    def filter(self, record):
+        message = record.getMessage()
+        return not (
+            record.name.startswith("fiasco")
+            and "was produced with an earlier version of fiasco" in message
+            and "You may need to rebuild the HDF5 database" in message
+        )
 
 
 def _ensure_hdf5_database(database_url, destination):
@@ -299,7 +301,7 @@ try:
 except ImportError:
     pass
 else:
-    fiasco.log.addFilter(_is_not_fiasco_database_version_warning)
+    fiasco.log.addFilter(_FiascoDatabaseVersionFilter())
 
 
 # -- Sphinx setup -------------------------------------------------------------

--- a/examples/analysis/02_mg_ii_dopplergrams.py
+++ b/examples/analysis/02_mg_ii_dopplergrams.py
@@ -13,7 +13,7 @@ import tarfile
 import matplotlib.pyplot as plt
 import numpy as np
 import pooch
-from scipy.interpolate import interp1d
+from scipy.interpolate import make_interp_spline
 
 import astropy.units as u
 from astropy import constants
@@ -69,8 +69,8 @@ plt.xlabel("Wavelength (nm)")
 # line intensity varies for a strong Mn I line at around 280.2 nm, in
 # between the Mg II k and h lines.
 #
-# For this dataset, the line core of this line falls around index 350.
-# Here though, we will crop in wavelength space.
+# For this dataset, the line core of this line falls around 280.2 nm.
+# We crop in wavelength space.
 
 lower_corner = [SpectralCoord(280.2, unit=u.nm), None]
 upper_corner = [SpectralCoord(280.2, unit=u.nm), None]
@@ -114,10 +114,17 @@ plt.xlabel("Scan number")
 # apply to this specific example).
 
 c = constants.c.to("km/s")
-wave_shift = -v_obs * mg_wave[350] / c
+mn_i_wavelength = 280.2 * u.nm
+wave_shift = -v_obs * mn_i_wavelength / c
 # Linear interpolation in wavelength, for each scan
 for i in range(mg_ii.data.shape[0]):
-    mg_ii.data[:, i, :] = interp1d(mg_wave - wave_shift[i], mg_ii.data[:, i, :], bounds_error=False)(mg_wave)
+    shifted_data = make_interp_spline(
+        (mg_wave - wave_shift[i]).to_value(u.nm),
+        mg_ii.data[i, :, :],
+        k=1,
+        axis=-1,
+    )(mg_wave.to_value(u.nm), extrapolate=False)
+    mg_ii.data[i, :, :] = np.nan_to_num(shifted_data, nan=0.0)
 
 ###############################################################################
 # Now we can plot the shifted data to see that the large scale shifts

--- a/examples/analysis/05_red_blue_asymmetry.py
+++ b/examples/analysis/05_red_blue_asymmetry.py
@@ -69,6 +69,7 @@ red_blue = calculate_red_blue_asymmetry(
     rest_wavelength=si_iv_rest,
     velocity_range=velocity_range,
     min_intensity=min_intensity,
+    return_profiles=True,
 )
 
 asymmetry = red_blue["red_blue_asymmetry"]

--- a/examples/analysis/06_oiv_density_diagnostics.py
+++ b/examples/analysis/06_oiv_density_diagnostics.py
@@ -11,7 +11,7 @@ they are often used to diagnose conditions in the solar transition region.
 .. warning::
 
     This example requires the optional density dependencies, including a version
-    of `fiasco` that provides ``fiasco.line_ratio_density``.
+    of `fiasco` that provides ``fiasco.line_ratio``.
 """
 
 import fiasco
@@ -63,7 +63,7 @@ fig, axes = plt.subplots(
     sharex=True,
 )
 
-line_ratio_density_kwargs = {"use_two_ion_model": False}
+line_ratio_kwargs = {"use_two_ion_model": False}
 for ax, (title, numerator, denominator) in zip(axes, ratio_definitions, strict=True):
     for line_style, label, ion in o4_models:
         diagnostic = density_diagnostic(
@@ -74,7 +74,7 @@ for ax, (title, numerator, denominator) in zip(axes, ratio_definitions, strict=T
             numerator=numerator,
             denominator=denominator,
             temperature=ion.temperature,
-            line_ratio_density_kwargs=line_ratio_density_kwargs,
+            line_ratio_kwargs=line_ratio_kwargs,
         )
         ax.plot(
             np.log10(diagnostic["density_grid"].to_value("cm-3")),
@@ -95,7 +95,7 @@ for ax, (title, numerator, denominator) in zip(axes, ratio_definitions, strict=T
                 numerator=numerator,
                 denominator=denominator,
                 temperature=ion.temperature,
-                line_ratio_density_kwargs=line_ratio_density_kwargs,
+                line_ratio_kwargs=line_ratio_kwargs,
             )
             ax.plot(
                 np.log10(observed["density"].to_value("cm-3")),

--- a/irispy/io/sji.py
+++ b/irispy/io/sji.py
@@ -217,9 +217,9 @@ def read_sji_lvl2(filename, *, uncertainty=False, memmap=False):
             unit = DN_UNIT["SJI_UNSCALED"]
         else:
             # This is a workaround for the AIA cubes being in int and not float
+            mask = data == BAD_PIXEL_VALUE_SCALED
             mask_value = BAD_PIXEL_VALUE_SCALED if np.issubdtype(data.dtype, np.integer) else np.nan
             data_nan_masked[data == BAD_PIXEL_VALUE_SCALED] = mask_value
-            mask = data_nan_masked == BAD_PIXEL_VALUE_SCALED
             scaled = True
             unit = DN_UNIT["SJI"]
             if uncertainty and instrume in ["IRIS", "SJI"]:

--- a/irispy/io/spectrograph.py
+++ b/irispy/io/spectrograph.py
@@ -86,8 +86,8 @@ def read_spectrograph_lvl2(
             spectral_windows_req = np.asarray(spectral_windows_req, dtype="U")
             window_is_in_obs = np.asarray([window in windows_in_obs for window in spectral_windows_req])
             if not all(window_is_in_obs):
-                missing_windows = window_is_in_obs is False
-                msg = f"Spectral windows {spectral_windows[missing_windows]} not in file {filenames[0]}"
+                missing_windows = spectral_windows_req[~window_is_in_obs]
+                msg = f"Spectral windows {missing_windows.tolist()} not in file {filenames[0]}"
                 raise ValueError(msg)
             window_fits_indices = np.nonzero(np.isin(windows_in_obs, spectral_windows))[0] + 1
         data_dict = {window_name: [] for window_name in spectral_windows_req}

--- a/irispy/io/tests/test_sji.py
+++ b/irispy/io/tests/test_sji.py
@@ -2,11 +2,13 @@ import numpy as np
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
 
 from sunpy.coordinates import Helioprojective
 
 from irispy.io.sji import read_sji_lvl2
+from irispy.utils.constants import BAD_PIXEL_VALUE_SCALED
 
 
 def test_sns_read_sji_lvl2(sns_sji_2832_file):
@@ -91,6 +93,15 @@ def test_raster_read_sji_lvl2(raster_sji_1400_file):
     assert meta.observatory_at_high_latitude is False
     assert meta.observing_campaign_start.isot == "2014-03-29T14:09:38.830"
     assert meta.observing_mode_description == "Very large coarse 8-step raster 14x175 8s  Si IV   Mg II h/k   Mg II"
+
+
+def test_read_sji_lvl2_masks_scaled_float_bad_pixels(sns_sji_1330_file):
+    expected_bad_pixels = np.count_nonzero(fits.getdata(sns_sji_1330_file, 0) == BAD_PIXEL_VALUE_SCALED)
+
+    cube = read_sji_lvl2(sns_sji_1330_file)
+
+    assert expected_bad_pixels > 0
+    assert cube.mask.sum() == expected_bad_pixels
 
 
 def test_smoke_read_sji_lvl2(

--- a/irispy/io/tests/test_sji.py
+++ b/irispy/io/tests/test_sji.py
@@ -104,6 +104,21 @@ def test_read_sji_lvl2_masks_scaled_float_bad_pixels(sns_sji_1330_file):
     assert cube.mask.sum() == expected_bad_pixels
 
 
+def test_read_sji_lvl2_masks_explicit_float_bad_pixels(tmp_path, sns_sji_1330_file):
+    with fits.open(sns_sji_1330_file) as hdul:
+        data = hdul[0].data.astype("float32")
+        data.flat[:2] = BAD_PIXEL_VALUE_SCALED
+        expected_bad_pixels = np.count_nonzero(data == BAD_PIXEL_VALUE_SCALED)
+        hdul[0].data = data
+        float_file = tmp_path / "sji_float_bad_pixels.fits"
+        hdul.writeto(float_file)
+
+    cube = read_sji_lvl2(float_file)
+
+    assert expected_bad_pixels > 0
+    assert cube.mask.sum() == expected_bad_pixels
+
+
 def test_smoke_read_sji_lvl2(
     sns_sji_1330_file,
     sns_sji_1400_file,

--- a/irispy/io/tests/test_spectrograph.py
+++ b/irispy/io/tests/test_spectrograph.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
@@ -160,3 +161,8 @@ def test_smoke_read_spectrograph_lvl2(sns_sg_file, raster_sg_file, raster_sg_fil
     read_spectrograph_lvl2(sns_sg_file)
     read_spectrograph_lvl2(raster_sg_file)
     read_spectrograph_lvl2(raster_sg_files)
+
+
+def test_read_spectrograph_lvl2_reports_missing_spectral_window(sns_sg_file):
+    with pytest.raises(ValueError, match=r"Spectral windows \['NOPE'\] not in file"):
+        read_spectrograph_lvl2(sns_sg_file, spectral_windows=["C II 1336", "NOPE"])

--- a/irispy/io/tests/test_utils.py
+++ b/irispy/io/tests/test_utils.py
@@ -121,6 +121,14 @@ def test_read_files_sji_more_than_one(sns_sji_1330_file, sns_sji_1400_file):
     assert len(returns) == 2
 
 
+def test_read_files_raises_when_no_files_are_supported(tmp_path):
+    filename = tmp_path / "not-a-fits.txt"
+    filename.write_text("not a supported IRIS file")
+
+    with pytest.raises(ValueError, match="No supported IRIS files were loaded"):
+        read_files(filename)
+
+
 @pytest.mark.remote_data
 def test_read_files_raster_scanning(remote_raster_scanning_tar):
     returns = read_files(remote_raster_scanning_tar)

--- a/irispy/io/utils.py
+++ b/irispy/io/utils.py
@@ -226,4 +226,7 @@ def read_files(filenames, *, spectral_windows=None, uncertainty=False, memmap=Fa
                 log.warning(f"File group {file_group} failed to load with {e}")
                 continue
             raise
+    if not returns:
+        msg = f"No supported IRIS files were loaded from {filenames}."
+        raise ValueError(msg)
     return NDCollection(returns.items()) if len(returns) > 1 else next(iter(returns.values()))

--- a/irispy/sji.py
+++ b/irispy/sji.py
@@ -3,6 +3,7 @@ import warnings
 from numbers import Integral
 
 import matplotlib.pyplot as plt
+import numpy as np
 
 from astropy.wcs import WCS
 
@@ -190,6 +191,8 @@ class SJICube(SpectrogramCube):
             If True, dust particles positions mask will be removed.
             Default=False
         """
+        if self.mask is None:
+            self.mask = np.zeros(self.data.shape, dtype=bool)
         dust_mask = calculate_dust_mask(self.data)
         if undo:
             # If undo kwarg IS set, unmask dust pixels.

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -64,6 +64,8 @@ class SpectrogramCube(SpecCube):
             result.unit,
             result.meta,
             mask=result.mask,
+            extra_coords=result.extra_coords,
+            global_coords=result.global_coords,
         )
 
     def __repr__(self) -> str:

--- a/irispy/tests/test_sji_fake_data.py
+++ b/irispy/tests/test_sji_fake_data.py
@@ -192,6 +192,15 @@ def test_sjicube_apply_dust_mask(dust_cube):
     np.testing.assert_array_equal(dust_cube.mask, before_mask)
 
 
+def test_sjicube_apply_dust_mask_initializes_missing_mask(dust_cube):
+    dust_cube.mask = None
+
+    dust_cube.apply_dust_mask()
+
+    assert dust_cube.mask is not None
+    assert dust_cube.mask.any()
+
+
 @pytest.mark.parametrize(
     ("item", "expected_len"),
     [

--- a/irispy/tests/test_spectrograph.py
+++ b/irispy/tests/test_spectrograph.py
@@ -24,6 +24,17 @@ def test_fits_data_comparison(sns_sg_file):
         np.testing.assert_array_almost_equal(iris_l2_test_raster[spectral_window3].data[0].data, data3)
 
 
+def test_spectrogram_cube_slice_preserves_coordinates(sns_sg_file):
+    raster = read_spectrograph_lvl2(sns_sg_file)
+    cube = raster["C II 1336"][0]
+
+    sliced_cube = cube[0]
+    sliced_sequence = cube[:1]
+
+    assert "time" in tuple(sliced_cube.global_coords)
+    assert "time" in tuple(sliced_sequence.extra_coords.keys())
+
+
 def test_spectrogram_cube_remove_cosmic_rays(sns_sg_file, monkeypatch):
     captured = {}
 

--- a/irispy/utils/density.py
+++ b/irispy/utils/density.py
@@ -5,7 +5,7 @@ Helpers for IRIS density diagnostics.
 from importlib import import_module
 
 import numpy as np
-from scipy.interpolate import interp1d
+from scipy.interpolate import make_interp_spline
 
 import astropy.units as u
 
@@ -78,13 +78,19 @@ def map_ratio_to_quantity(observed_ratio, quantity, theoretical_ratio, *, bounds
     elif isinstance(fill_value, u.Quantity):
         fill_value = fill_value.to_value(quantity.unit)
 
-    interp = interp1d(
-        theoretical_ratio,
-        quantity.value,
-        bounds_error=bounds_error,
-        fill_value=fill_value,
+    observed_values = observed_ratio.to_value(u.dimensionless_unscaled)
+    outside = (observed_values < theoretical_ratio[0]) | (observed_values > theoretical_ratio[-1])
+    if bounds_error and np.any(outside):
+        msg = "observed_ratio contains values outside the theoretical ratio range."
+        raise ValueError(msg)
+
+    if isinstance(fill_value, tuple):
+        left, right = fill_value
+    else:
+        left = right = fill_value
+    return u.Quantity(
+        np.interp(observed_values, theoretical_ratio, quantity.value, left=left, right=right), quantity.unit
     )
-    return u.Quantity(interp(observed_ratio.to_value(u.dimensionless_unscaled)), quantity.unit)
 
 
 def density_diagnostic(
@@ -211,14 +217,19 @@ def density_diagnostic(
                 ratio_temperature = u.Quantity(ion.formation_temperature)
         else:
             ratio_temperature = u.Quantity(temperature)
-        if ratio_temperature.size == 1:
-            ratio_temperature = ratio_temperature.flat[0]
+        if ratio_temperature.size != 1:
+            msg = "temperature must be scalar."
+            raise ValueError(msg)
+        ratio_temperature = ratio_temperature.flat[0]
 
         order = np.argsort(ion_temperature.to_value(u.K))
         temperature_grid = ion_temperature.to_value(u.K)[order]
         ratio_values = theoretical_ratio.value[order]
-        interp = interp1d(temperature_grid, ratio_values, axis=0, bounds_error=False, fill_value=np.nan)
-        theoretical_ratio = u.Quantity(interp(ratio_temperature.to_value(u.K)), theoretical_ratio.unit).squeeze()
+        interp = make_interp_spline(temperature_grid, ratio_values, k=1, axis=0)
+        theoretical_ratio = u.Quantity(
+            interp(ratio_temperature.to_value(u.K), extrapolate=False),
+            theoretical_ratio.unit,
+        ).squeeze()
 
     density_grid = u.Quantity(density_grid)
     theoretical_ratio = u.Quantity(theoretical_ratio, u.dimensionless_unscaled)

--- a/irispy/utils/density.py
+++ b/irispy/utils/density.py
@@ -65,6 +65,9 @@ def map_ratio_to_quantity(observed_ratio, quantity, theoretical_ratio, *, bounds
         )
         raise ValueError(msg)
 
+    order = np.argsort(theoretical_ratio)
+    theoretical_ratio = theoretical_ratio[order]
+    quantity = quantity[order]
     theoretical_ratio, unique_index = np.unique(theoretical_ratio, return_index=True)
     quantity = quantity[unique_index]
     if quantity.size < 2:
@@ -106,7 +109,7 @@ def density_diagnostic(
     temperature=None,
     bounds_error=False,
     fill_value=np.nan,
-    line_ratio_density_kwargs=None,
+    line_ratio_kwargs=None,
 ):
     """
     Map an observed IRIS line ratio onto a theoretical density curve.
@@ -132,8 +135,8 @@ def density_diagnostic(
         Passed through to `map_ratio_to_quantity`.
     fill_value : scalar or `~astropy.units.Quantity`, optional
         Passed through to `map_ratio_to_quantity`.
-    line_ratio_density_kwargs : `dict`, optional
-        Extra keyword arguments forwarded to ``fiasco.line_ratio_density``.
+    line_ratio_kwargs : `dict`, optional
+        Extra keyword arguments forwarded to ``fiasco.line_ratio``.
     """
     if (intensity_numerator_uncertainty is None) != (intensity_denominator_uncertainty is None):
         msg = "Both numerator and denominator uncertainties must be provided together."
@@ -148,8 +151,8 @@ def density_diagnostic(
         msg = "IRIS density diagnostics require the optional dependency 'fiasco'."
         raise ImportError(msg) from exc
 
-    if line_ratio_density_kwargs is None:
-        line_ratio_density_kwargs = {}
+    if line_ratio_kwargs is None:
+        line_ratio_kwargs = {}
 
     intensity_numerator = u.Quantity(intensity_numerator)
     intensity_denominator = u.Quantity(intensity_denominator)
@@ -197,12 +200,12 @@ def density_diagnostic(
             raise ValueError(msg) from exc
         ratio_uncertainty = u.Quantity(ratio_uncertainty, ratio.unit)
 
-    theoretical_ratio = fiasco.line_ratio_density(
+    theoretical_ratio = fiasco.line_ratio(
         ion,
         numerator,
         denominator,
         density_grid,
-        **line_ratio_density_kwargs,
+        **line_ratio_kwargs,
     )
     theoretical_ratio = u.Quantity(theoretical_ratio, u.dimensionless_unscaled).squeeze()
     if theoretical_ratio.ndim > 1:

--- a/irispy/utils/moments.py
+++ b/irispy/utils/moments.py
@@ -102,20 +102,21 @@ def calculate_moments(
     * `arXiv:2005.02029, Section 3.1 <https://arxiv.org/abs/2005.02029>`__
     * `Færder et al. (2024), ApJ, Appendix C <https://iopscience.iop.org/article/10.3847/1538-4357/ac4223>`__
     """
-    wavelength_axis = next(
-        axis
-        for axis, physical_types in enumerate(cube.array_axis_physical_types)
-        if physical_types and "em.wl" in physical_types
-    )
+    try:
+        wavelength_axis = next(
+            axis
+            for axis, physical_types in enumerate(cube.array_axis_physical_types)
+            if physical_types and "em.wl" in physical_types
+        )
+    except StopIteration as exc:
+        msg = "Could not identify a spectral wavelength axis on the input cube"
+        raise ValueError(msg) from exc
     wavelengths = cube.axis_world_coords(wavelength_axis)[0]
     if not isinstance(wavelengths, u.Quantity):
         wavelengths = wavelengths * u.one
     wavelengths = wavelengths.to(u.nm)
-    data = cube.data.copy()
-    if cube.mask is not None:
-        data = np.where(cube.mask, 0, data)
-    data = np.where(data < 0, 0, data)
-    data = np.where(np.isfinite(data), data, 0)
+    data = np.asarray(cube.data)
+    mask = None if cube.mask is None else np.asarray(cube.mask, dtype=bool)
     if wings is not None:
         if rest_wavelength is None:
             msg = "rest_wavelength must be provided when wings is given"
@@ -133,7 +134,13 @@ def calculate_moments(
         slicer = [slice(None)] * data.ndim
         slicer[wavelength_axis] = crop_indices
         data = data[tuple(slicer)]
+        if mask is not None:
+            mask = mask[tuple(slicer)]
         wavelengths = wavelengths[crop_mask]
+    data = np.array(data, dtype=float, copy=True)
+    if mask is not None:
+        data[mask] = 0
+    data[(data < 0) | ~np.isfinite(data)] = 0
     # Calculate wavelength step (assumed uniform)
     dwvl = np.mean(np.diff(wavelengths))
     # Move wavelength axis to the end for vectorised computation

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -6,7 +6,7 @@ import warnings
 from enum import IntEnum
 
 import numpy as np
-from scipy.interpolate import interp1d
+from scipy.interpolate import make_interp_spline
 
 import astropy.units as u
 from astropy import constants
@@ -19,6 +19,8 @@ from irispy.spectrograph import RasterCollection, SpectrogramCube
 from irispy.utils._spectral import drop_extra_coords_dependent_on_axis, make_map_cube, make_spatial_template
 
 __all__ = ["RBAQualityFlag", "calculate_red_blue_asymmetry"]
+
+_INTERPOLATION_DEGREES = {"linear": 1, "quadratic": 2, "cubic": 3}
 
 
 class RBAQualityFlag(IntEnum):
@@ -114,6 +116,7 @@ def calculate_red_blue_asymmetry(
     mask_negative=True,
     min_intensity=None,
     saturation_limit=None,
+    return_profiles=True,
 ):
     """
     Calculate red-blue asymmetry maps from a spectrogram cube.
@@ -149,8 +152,8 @@ def calculate_red_blue_asymmetry(
     uncertainty : `astropy.units.Quantity`, optional
         Per-bin intensity uncertainty. If omitted, ``cube.uncertainty`` is
         used when available.
-    interpolation_kind : `str`, optional
-        Interpolation method passed to `scipy.interpolate.interp1d`.
+    interpolation_kind : {"linear", "quadratic", "cubic"} or `int`, optional
+        Spline degree used by `scipy.interpolate.make_interp_spline`.
     mask_negative : `bool`, optional
         If `True`, negative intensities are set to NaN before computing
         moments.
@@ -162,15 +165,19 @@ def calculate_red_blue_asymmetry(
         Maximum allowed peak intensity. Pixels where the peak exceeds this
         value are treated as saturated, skipped, and assigned quality flag
         `~irispy.utils.red_blue.RBAQualityFlag.SATURATED`.
+    return_profiles : `bool`, optional
+        If `True`, include plot-ready 3D ``"observed_profile"`` and
+        ``"interpolated_profile"`` cubes in the output. Set to `False` to
+        reduce peak memory use when only the 2D maps are needed.
 
     Returns
     -------
     `irispy.spectrograph.RasterCollection`
-        Collection with 2D maps and plot-ready 3D ``"observed_profile"`` and
+        Collection with 2D maps. When ``return_profiles=True``, the collection
+        also includes plot-ready 3D ``"observed_profile"`` and
         ``"interpolated_profile"`` `~irispy.spectrograph.SpectrogramCube`
-        instances. Index either profile cube by spatial pixel to plot a 1D
-        line profile against its velocity WCS. The ``"quality"`` cube stores
-        per-pixel integer flags described by
+        instances. The ``"quality"`` cube stores per-pixel integer flags
+        described by
         `irispy.utils.red_blue.RBAQualityFlag`.
     """
     # -- Validate velocity_range ------------------------------------------------
@@ -196,6 +203,15 @@ def calculate_red_blue_asymmetry(
         raise ValueError(msg)
     if dv <= 0:
         msg = "dv must be positive"
+        raise ValueError(msg)
+    interpolation_degree = _INTERPOLATION_DEGREES.get(interpolation_kind, interpolation_kind)
+    try:
+        interpolation_degree = int(interpolation_degree)
+    except (TypeError, ValueError) as exc:
+        msg = "interpolation_kind must be 'linear', 'quadratic', 'cubic', or an integer spline degree"
+        raise ValueError(msg) from exc
+    if interpolation_degree < 0:
+        msg = "interpolation_kind must be a non-negative spline degree"
         raise ValueError(msg)
 
     # -- Locate spectral axis and compute velocities ----------------------------
@@ -290,9 +306,13 @@ def calculate_red_blue_asymmetry(
         saturated = raw_peak > saturation_limit_value
         quality = np.where(saturated, RBAQualityFlag.SATURATED, quality)
 
-    interpolated_profiles = np.full((*output_shape, interp_velocity.size), np.nan, dtype=float)
+    interpolated_profiles = (
+        np.full((*output_shape, interp_velocity.size), np.nan, dtype=float) if return_profiles else None
+    )
     interpolated_errors = (
-        np.full((*output_shape, interp_velocity.size), np.nan, dtype=float) if errors is not None else None
+        np.full((*output_shape, interp_velocity.size), np.nan, dtype=float)
+        if errors is not None and return_profiles
+        else None
     )
 
     low, high = velocity_range_value
@@ -335,34 +355,41 @@ def calculate_red_blue_asymmetry(
 
         # Interpolate onto uniform velocity grid
         finite = np.isfinite(shifted_velocity) & np.isfinite(profile)
-        min_points = 4 if interpolation_kind == "cubic" else 2
+        min_points = interpolation_degree + 1
         if finite.sum() < min_points:
             quality[index] = RBAQualityFlag.TOO_FEW_POINTS
             continue
         sv = shifted_velocity[finite]
         sp = profile[finite]
         order = np.argsort(sv)
+        ordered_velocity = sv[order]
+        ordered_profile = sp[order]
         try:
-            interp_profile = interp1d(
-                sv[order], sp[order], kind=interpolation_kind, bounds_error=False, fill_value=np.nan
-            )(interp_velocity)
+            interp_profile = make_interp_spline(ordered_velocity, ordered_profile, k=interpolation_degree)(
+                interp_velocity,
+                extrapolate=False,
+            )
         except ValueError:
             quality[index] = RBAQualityFlag.INTERP_FAILED
             continue
         if profile_error is not None:
-            se = profile_error[finite][order]
-            if np.isfinite(se).sum() >= min_points:
-                interp_error = interp1d(sv[order], se, kind=interpolation_kind, bounds_error=False, fill_value=np.nan)(
-                    interp_velocity
-                )
+            ordered_error = profile_error[finite][order]
+            finite_error = np.isfinite(ordered_error)
+            if finite_error.sum() >= min_points:
+                interp_error = make_interp_spline(
+                    ordered_velocity[finite_error],
+                    ordered_error[finite_error],
+                    k=interpolation_degree,
+                )(interp_velocity, extrapolate=False)
                 interp_error = np.where(interp_error >= 0, interp_error, np.nan)
             else:
                 interp_error = None
         else:
             interp_error = None
 
-        interpolated_profiles[index] = interp_profile
-        if interp_error is not None:
+        if return_profiles:
+            interpolated_profiles[index] = interp_profile
+        if interp_error is not None and return_profiles:
             interpolated_errors[index] = interp_error
 
         red_finite = red_mask & np.isfinite(interp_profile)
@@ -440,44 +467,45 @@ def calculate_red_blue_asymmetry(
             ],
         )
 
-    observed_data = np.moveaxis(data, -1, wavelength_axis)
-    observed_mask = ~np.isfinite(observed_data)
-    observed_uncertainty = None
-    if errors is not None:
-        observed_uncertainty = StdDevUncertainty(np.moveaxis(errors, -1, wavelength_axis))
+    if return_profiles:
+        observed_data = np.moveaxis(data, -1, wavelength_axis)
+        observed_mask = ~np.isfinite(observed_data)
+        observed_uncertainty = None
+        if errors is not None:
+            observed_uncertainty = StdDevUncertainty(np.moveaxis(errors, -1, wavelength_axis))
 
-    interpolated_data = np.moveaxis(interpolated_profiles, -1, wavelength_axis)
-    interpolated_mask = ~np.isfinite(interpolated_data)
-    interpolated_uncertainty = None
-    if interpolated_errors is not None:
-        interpolated_uncertainty = StdDevUncertainty(np.moveaxis(interpolated_errors, -1, wavelength_axis))
+        interpolated_data = np.moveaxis(interpolated_profiles, -1, wavelength_axis)
+        interpolated_mask = ~np.isfinite(interpolated_data)
+        interpolated_uncertainty = None
+        if interpolated_errors is not None:
+            interpolated_uncertainty = StdDevUncertainty(np.moveaxis(interpolated_errors, -1, wavelength_axis))
 
-    cubes.extend(
-        [
-            (
-                "observed_profile",
-                _make_profile_cube(
-                    cube,
-                    data=observed_data,
-                    velocity_grid=velocity,
-                    wavelength_axis=wavelength_axis,
-                    meta={**cube.meta, **meta, "rba_profile": "observed"},
-                    uncertainty=observed_uncertainty,
-                    mask=observed_mask,
+        cubes.extend(
+            [
+                (
+                    "observed_profile",
+                    _make_profile_cube(
+                        cube,
+                        data=observed_data,
+                        velocity_grid=velocity,
+                        wavelength_axis=wavelength_axis,
+                        meta={**cube.meta, **meta, "rba_profile": "observed"},
+                        uncertainty=observed_uncertainty,
+                        mask=observed_mask,
+                    ),
                 ),
-            ),
-            (
-                "interpolated_profile",
-                _make_profile_cube(
-                    cube,
-                    data=interpolated_data,
-                    velocity_grid=interp_velocity,
-                    wavelength_axis=wavelength_axis,
-                    meta={**cube.meta, **meta, "rba_profile": "interpolated_peak_centered"},
-                    uncertainty=interpolated_uncertainty,
-                    mask=interpolated_mask,
+                (
+                    "interpolated_profile",
+                    _make_profile_cube(
+                        cube,
+                        data=interpolated_data,
+                        velocity_grid=interp_velocity,
+                        wavelength_axis=wavelength_axis,
+                        meta={**cube.meta, **meta, "rba_profile": "interpolated_peak_centered"},
+                        uncertainty=interpolated_uncertainty,
+                        mask=interpolated_mask,
+                    ),
                 ),
-            ),
-        ]
-    )
+            ]
+        )
     return RasterCollection(cubes)

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -376,12 +376,16 @@ def calculate_red_blue_asymmetry(
             ordered_error = profile_error[finite][order]
             finite_error = np.isfinite(ordered_error)
             if finite_error.sum() >= min_points:
-                interp_error = make_interp_spline(
-                    ordered_velocity[finite_error],
-                    ordered_error[finite_error],
-                    k=interpolation_degree,
-                )(interp_velocity, extrapolate=False)
-                interp_error = np.where(interp_error >= 0, interp_error, np.nan)
+                try:
+                    interp_error = make_interp_spline(
+                        ordered_velocity[finite_error],
+                        ordered_error[finite_error],
+                        k=interpolation_degree,
+                    )(interp_velocity, extrapolate=False)
+                    interp_error = np.where(interp_error >= 0, interp_error, np.nan)
+                except ValueError:
+                    quality[index] = RBAQualityFlag.INTERP_FAILED
+                    continue
             else:
                 interp_error = None
         else:

--- a/irispy/utils/tests/test_density.py
+++ b/irispy/utils/tests/test_density.py
@@ -12,15 +12,15 @@ from irispy.utils.density import density_diagnostic, map_ratio_to_quantity
 def _install_fake_fiasco(monkeypatch, ratio):
     calls = {}
 
-    def line_ratio_density(ion, numerator, denominator, density_grid, **kwargs):
+    def line_ratio(ion, numerator, denominator, density_grid, **kwargs):
         calls["ion"] = ion
         calls["numerator"] = numerator
         calls["denominator"] = denominator
         calls["density_grid"] = density_grid
-        calls["line_ratio_density_kwargs"] = kwargs
+        calls["line_ratio_kwargs"] = kwargs
         return u.Quantity(ratio, u.dimensionless_unscaled)
 
-    fake_fiasco = types.SimpleNamespace(line_ratio_density=line_ratio_density)
+    fake_fiasco = types.SimpleNamespace(line_ratio=line_ratio)
     monkeypatch.setitem(sys.modules, "fiasco", fake_fiasco)
     return calls
 
@@ -99,12 +99,12 @@ def test_density_diagnostic_builds_theoretical_ratio_with_fiasco(monkeypatch):
         ion=fake_ion,
         numerator=1399.78 * u.angstrom,
         denominator=1401.16 * u.angstrom,
-        line_ratio_density_kwargs={"use_two_ion_model": False},
+        line_ratio_kwargs={"use_two_ion_model": False},
     )
 
     assert calls["ion"] is fake_ion
     assert u.allclose(calls["density_grid"], density_grid)
-    assert calls["line_ratio_density_kwargs"] == {"use_two_ion_model": False}
+    assert calls["line_ratio_kwargs"] == {"use_two_ion_model": False}
     np.testing.assert_allclose(result["theoretical_ratio"].value, [0.2, 0.4, 0.6])
     assert u.allclose(result["density"], [2] * u.cm**-3)
 

--- a/irispy/utils/tests/test_density.py
+++ b/irispy/utils/tests/test_density.py
@@ -210,6 +210,32 @@ def test_density_diagnostic_explicit_temperature(monkeypatch):
     assert u.allclose(result["density"], [2] * u.cm**-3)
 
 
+def test_density_diagnostic_rejects_vector_temperature(monkeypatch):
+    _install_fake_fiasco(
+        monkeypatch,
+        [
+            [0.1, 0.2, 0.3],
+            [0.2, 0.4, 0.6],
+            [0.3, 0.6, 0.9],
+        ],
+    )
+    fake_ion = types.SimpleNamespace(
+        temperature=[1e5, 2e5, 3e5] * u.K,
+        formation_temperature=1e5 * u.K,
+    )
+
+    with pytest.raises(ValueError, match="temperature must be scalar"):
+        density_diagnostic(
+            [0.4],
+            [1.0],
+            [1, 2, 3] * u.cm**-3,
+            ion=fake_ion,
+            numerator=1399.78 * u.angstrom,
+            denominator=1401.16 * u.angstrom,
+            temperature=[1e5, 2e5] * u.K,
+        )
+
+
 def test_density_diagnostic_uncertainty_shape_mismatch(monkeypatch):
     _install_fake_fiasco(monkeypatch, [0.5, 1.0])
     fake_ion = types.SimpleNamespace(

--- a/irispy/utils/tests/test_moments.py
+++ b/irispy/utils/tests/test_moments.py
@@ -125,6 +125,22 @@ def test_calculate_moments_requires_wavelength_axis():
         calculate_moments(cube)
 
 
+def test_calculate_moments_ignores_negative_nonfinite_and_masked_values():
+    wavelengths = np.arange(4) * u.nm
+    clean_cube = make_test_spectrogram_cube(np.array([[[1.0, 0.0, 0.0, 0.0]]]), wavelengths)
+
+    dirty_cube = make_test_spectrogram_cube(np.array([[[1.0, -5.0, np.nan, 10.0]]]), wavelengths)
+    dirty_cube.mask = np.array([[[False, False, False, True]]])
+
+    clean_moments = calculate_moments(clean_cube)
+    dirty_moments = calculate_moments(dirty_cube)
+
+    assert clean_moments.keys() == dirty_moments.keys()
+    for key in clean_moments:
+        assert clean_moments[key].unit == dirty_moments[key].unit
+        np.testing.assert_allclose(dirty_moments[key].data, clean_moments[key].data, equal_nan=True)
+
+
 def test_calculate_moments_known_gaussian():
     """
     Test calculate_moments against a known Gaussian profile.

--- a/irispy/utils/tests/test_moments.py
+++ b/irispy/utils/tests/test_moments.py
@@ -115,6 +115,16 @@ def test_calculate_moments_wings_without_rest_wavelength(sns_sg_file):
         calculate_moments(cube, wings=1.0 * u.Angstrom)
 
 
+def test_calculate_moments_requires_wavelength_axis():
+    cube = make_test_spectrogram_cube(np.ones((1, 1, 5)), np.arange(5) * u.nm)
+    cube.wcs.wcs.ctype[0] = "TIME"
+    cube.wcs.wcs.cunit[0] = "s"
+    cube.wcs.wcs.set()
+
+    with pytest.raises(ValueError, match="Could not identify a spectral wavelength axis"):
+        calculate_moments(cube)
+
+
 def test_calculate_moments_known_gaussian():
     """
     Test calculate_moments against a known Gaussian profile.

--- a/irispy/utils/tests/test_red_blue.py
+++ b/irispy/utils/tests/test_red_blue.py
@@ -82,7 +82,7 @@ def test_calculate_red_blue_asymmetry_uses_masked_bins():
         center_on_peak=False,
     )
 
-    assert_quantity_allclose(result["red_blue_asymmetry"].data[0, 0] * u.one, 0 * u.one)
+    assert_quantity_allclose(result["red_blue_asymmetry"].data[0, 0] * u.one, 0 * u.one, atol=1e-12 * u.one)
 
 
 def test_calculate_red_blue_asymmetry_output_does_not_inherit_first_wavelength_mask():
@@ -261,6 +261,25 @@ def test_calculate_red_blue_asymmetry_return_profiles_on_sliced_cube():
         result["interpolated_profile"][0, 0].axis_world_coords(0)[0],
         np.arange(-200, 201, 10) * u.km / u.s,
     )
+
+
+def test_calculate_red_blue_asymmetry_can_skip_profile_outputs():
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    profile = _flat_wing_profile(velocity, red_excess=2)
+    cube = make_test_spectrogram_cube(profile.reshape(1, 1, -1), wavelengths)
+
+    result = calculate_red_blue_asymmetry(
+        cube,
+        rest_wavelength=REST_WAVELENGTH,
+        interpolation_kind="linear",
+        center_on_peak=False,
+        return_profiles=False,
+    )
+
+    assert "observed_profile" not in result
+    assert "interpolated_profile" not in result
+    assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
 
 
 def test_calculate_red_blue_asymmetry_flags_incomplete_wings():

--- a/irispy/utils/tests/test_red_blue.py
+++ b/irispy/utils/tests/test_red_blue.py
@@ -6,6 +6,7 @@ from astropy import constants
 from astropy.nddata import StdDevUncertainty
 from astropy.tests.helper import assert_quantity_allclose
 
+import irispy.utils.red_blue as red_blue_module
 from irispy.io.utils import read_files
 from irispy.spectrograph import RasterCollection, SpectrogramCube
 from irispy.tests.helpers import make_test_spectrogram_cube
@@ -168,6 +169,35 @@ def test_calculate_red_blue_asymmetry_with_uncertainty():
     # Meta should record the parameters used
     assert result["red_blue_asymmetry"].meta["rba_rest_wavelength"] == 140.277
     assert result["red_blue_asymmetry"].meta["rba_center_on_peak"] is False
+
+
+def test_calculate_red_blue_asymmetry_flags_error_interpolation_failure(monkeypatch):
+    original_make_interp_spline = red_blue_module.make_interp_spline
+    calls = 0
+
+    def fail_on_error_spline(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            msg = "error spline failed"
+            raise ValueError(msg)
+        return original_make_interp_spline(*args, **kwargs)
+
+    monkeypatch.setattr(red_blue_module, "make_interp_spline", fail_on_error_spline)
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    cube = make_test_spectrogram_cube(_flat_wing_profile(velocity, red_excess=2).reshape(1, 1, -1), wavelengths)
+
+    result = calculate_red_blue_asymmetry(
+        cube,
+        rest_wavelength=REST_WAVELENGTH,
+        uncertainty=np.full(cube.shape, 0.1) * u.DN,
+        interpolation_kind="linear",
+        center_on_peak=False,
+    )
+
+    assert RBAQualityFlag(result["quality"].data[0, 0]) is RBAQualityFlag.INTERP_FAILED
+    assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
 
 
 def test_calculate_red_blue_asymmetry_center_on_peak():

--- a/irispy/utils/tests/test_utils.py
+++ b/irispy/utils/tests/test_utils.py
@@ -38,3 +38,10 @@ def test_get_detector_type(test_input, expected_output):
 @pytest.mark.parametrize(("input_array", "expected_array"), [(data_dust, dust_mask_expected)])
 def test_calculate_dust_mask(input_array, expected_array):
     np_test.assert_array_equal(utils.calculate_dust_mask(input_array), expected_array)
+
+
+def test_calculate_dust_mask_2d():
+    data = np.ones((3, 3))
+    data[1, 1] = 0
+
+    np_test.assert_array_equal(utils.calculate_dust_mask(data), np.ones((3, 3), dtype=bool))

--- a/irispy/utils/utils.py
+++ b/irispy/utils/utils.py
@@ -138,7 +138,13 @@ def calculate_dust_mask(data_array):
     # Set the pixel value to True is the pixel is recognized as a dust pixel.
     mask[(data_array < 0.5) & (data_array > BAD_PIXEL_VALUE_SCALED)] = True
     # Extending the mask to avoid the neighbours pixel influenced by the dust pixels.
-    struct = np.array([np.zeros((3, 3)), np.ones((3, 3)), np.zeros((3, 3))], dtype=bool)
+    if mask.ndim == 2:
+        struct = np.ones((3, 3), dtype=bool)
+    elif mask.ndim == 3:
+        struct = np.array([np.zeros((3, 3)), np.ones((3, 3)), np.zeros((3, 3))], dtype=bool)
+    else:
+        msg = "data_array must be 2D or 3D."
+        raise ValueError(msg)
     return ndimage.binary_dilation(mask, structure=struct).astype(mask.dtype)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ optional-dependencies.cosmic-rays = [
   "rsliding",
 ]
 optional-dependencies.density = [
-  # TODO: Switch to PyPI release once fiasco.line_ratio_density is released.
+  # TODO: Switch to PyPI release once fiasco.line_ratio is released.
   "fiasco @ git+https://github.com/nabobalis/fiasco.git@ratio-feature",
 ]
 optional-dependencies.dev = [


### PR DESCRIPTION
## Summary by Sourcery

Improve spectral interpolation, masking, and error handling across red-blue asymmetry, density diagnostics, moments, and IO utilities, while tightening validation and adding regression tests.

New Features:
- Allow red-blue asymmetry calculations to skip profile cube outputs via a new return_profiles option.
- Support configurable spline degrees for red-blue asymmetry interpolation via string aliases or integer degrees.

Bug Fixes:
- Ensure red-blue asymmetry, density diagnostics, and moments computations handle masks, interpolation bounds, and missing spectral axes more robustly.
- Fix SJI and spectrograph readers to mask scaled bad pixels, report missing spectral windows, and error when no supported files are loaded.
- Ensure dust mask calculation works for both 2D and 3D data and initialize missing masks before applying dust masks.
- Prevent vector temperatures in density diagnostics and enforce scalar temperature input.
- Suppress noisy fiasco database version warnings and validate/download the docs HDF5 database safely.

Enhancements:
- Replace several linear interpolations with spline-based interpolation for more stable profile and ratio evaluation.
- Adjust examples to use physically meaningful wavelengths and spline-based shifting of Mg II data.
- Preserve extra and global coordinates when slicing spectrogram cubes to maintain metadata consistency.

Documentation:
- Update documentation build configuration to manage the CHIANTI HDF5 database more robustly and filter irrelevant fiasco warnings.

Tests:
- Add regression tests covering new interpolation behavior, profile-skipping, scalar temperature enforcement, dust masking edge cases, file loading errors, bad-pixel masking, spectral-window validation, and coordinate preservation.