### PR TITLE
Add gallery profiling controls

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-26.04"
+  os: "ubuntu-lts-latest"
   tools:
     python: "miniforge3-latest"
   jobs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,10 @@ if on_rtd:
     os.environ["LC_ALL"] = "C"
     os.environ["PARFIVE_HIDE_PROGRESS"] = "True"
 
+# Enable extra Sphinx-Gallery runtime and memory reporting only for the
+# GitHub Actions gallery tox job. Do not enable this on Read the Docs.
+profile_gallery = os.environ.get("IRISPY_GALLERY_PROFILE") == "1" and not on_rtd
+
 # -- Project information ------------------------------------------------------
 
 # The full version, including alpha/beta/rc tags
@@ -58,6 +62,15 @@ warnings.filterwarnings("error", category=SunpyDeprecationWarning)
 warnings.filterwarnings("error", category=SunpyPendingDeprecationWarning)
 warnings.filterwarnings("error", category=MatplotlibDeprecationWarning)
 warnings.filterwarnings("error", category=AstropyDeprecationWarning)
+
+# Suppress spurious RuntimeWarning from astropy's Angle.to_string() vectorized
+# formatter (astropy/astropy#18989). It fires benignly when WCSAxes formats tick
+# labels and can appear during gallery builds for examples with grid/contour plots.
+warnings.filterwarnings(
+    "ignore",
+    message="invalid value encountered in do_format",
+    category=RuntimeWarning,
+)
 
 # Wrap large function/method signatures
 maximum_signature_line_length = 80
@@ -213,6 +226,8 @@ sphinx_gallery_conf = {
     "doc_module": ("sunpy"),
     "only_warn_on_example_error": True,
     "matplotlib_animations": True,
+    "write_computation_times": profile_gallery,
+    "show_memory": profile_gallery,
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ set_env =
     COLUMNS = 180
     MPLBACKEND = agg
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    gallery: IRISPY_GALLERY_PROFILE = 1
 deps =
     # For packages which publish nightly wheels this will pull the latest nightly
     # devdeps: numpy>=0.0.dev0
@@ -85,6 +86,8 @@ change_dir = docs
 description = Invoke sphinx-build to build the HTML docs
 extras = dev
 deps =
+    gallery: memory_profiler
+    gallery: psutil
     live: sphinx-autobuild
 commands_pre =
     pip freeze --all --no-input
@@ -102,6 +105,7 @@ commands =
     _build/html \
     !gallery: -D plot_gallery=0 \
     {posargs}
+    gallery: python -c 'from pathlib import Path; files=sorted(Path("generated/gallery").glob("**/sg_execution_times.rst")); print("Sphinx-Gallery execution time reports:"); [print("\n" + str(path) + "\n" + path.read_text()) for path in files]'
     python -c 'import pathlib; print("Documentation available under file://\{0\}".format(pathlib.Path(r"{toxinidir}") / "docs" / "_build" / "index.html"))'
 
 [testenv:codestyle]


### PR DESCRIPTION
## Summary by Sourcery

Add optional profiling and reporting for Sphinx-Gallery example execution during CI gallery builds while keeping Read the Docs builds unchanged.

Build:
- Configure Sphinx-Gallery to optionally record computation times and memory usage when a dedicated gallery profiling environment variable is set.
- Update tox gallery docs environment to enable gallery profiling, install memory profiling dependencies, and print Sphinx-Gallery execution time reports after the build.
- Update Read the Docs configuration to use the latest Ubuntu LTS build image.

Documentation:
- Suppress a known benign astropy RuntimeWarning during docs and gallery builds to avoid noisy output.