### PR TITLE
Add raster spectrum_at lookup

### DIFF
--- a/changelog/999.feature.rst
+++ b/changelog/999.feature.rst
@@ -1,0 +1,1 @@
+Added `~irispy.spectrograph.SpectrogramCube.spectrum_at` as a convenience wrapper for raster sky-position lookups.

--- a/docs/tutorial/level_2.rst
+++ b/docs/tutorial/level_2.rst
@@ -111,23 +111,27 @@ Let us retrieve the header of the raster file and display the description of the
 
 .. note::
     By default, this will load the data into memory.
-    You can pass ``memmap=True`` to avoid this; the data array will be a `numpy.memmap` instead.
-    In this case, the data are not loaded into system memory, but written to a temporary file.
+    You can pass ``memmap=True`` to keep raster data lazy.
+    Single-file reads remain file-backed, while multi-file rasters are exposed as one
+    dask-backed cube that reads each file chunk on demand.
 
 We can print the ``raster`` object to get some basic information about the raster file: what spectral windows were observed, the size of the cube, and the wavelength keys.
 
 .. code-block:: python
 
-    >>> raster  # doctest: +REMOTE_DATA
+    >>> raster  # doctest: +REMOTE_DATA, +ELLIPSIS
     <irispy.spectrograph.RasterCollection object at ...>
     <BLANKLINE>
     Raster Collection
     -----------------
     Spectral Windows (cube keys): (np.str_('C II 1336'), np.str_('Si IV 1394'), np.str_('Mg II k 2796'))
     Number of Cubes: 3
-    Aligned dimensions: [5 16 548]
-    Aligned physical types: [('meta.obs.sequence',), ...]
+    Aligned dimensions: ...
+    Aligned physical types: ...
     <BLANKLINE>
+
+Each value in the ``RasterCollection`` is a spectral-window cube. For repeated rasters,
+that cube spans the full observation along the scan axis.
 
 Let us check the metadata of this collection, this is stored as a ``meta`` attribute:
 
@@ -150,7 +154,8 @@ Let us check the metadata of this collection, this is stored as a ``meta`` attri
     OBS Description: Very large sparse 16-step raster 15x175 16s   Deep x 0.5 Spatial x 2
     <BLANKLINE>
 
-Note this is not on the main object but each individual element, in this case the spectral window.
+The `~irispy.spectrograph.RasterCollection` itself groups spectral windows, so the metadata lives on each
+spectral-window cube rather than on the collection.
 While SJI files contain just one spectral window per file, raster files have several spectral windows per file.
 
 If we want to check the primary header of the raster, we can do the following:

--- a/examples/calibration/01_remove_spikes.py
+++ b/examples/calibration/01_remove_spikes.py
@@ -3,11 +3,11 @@
 Remove Cosmic Ray Hits from IRIS data
 =====================================
 
-This example illustrates how to remove cosmic ray hits from IRIS SJI data.
+This example illustrates how to remove cosmic ray hits from IRIS data.
 
 We will use the ``astroscrappy`` backend and has to be installed separately using ``pip`` or ``conda``.
 
-``irispy`` supports two backends for cosmic ray removal, they are compared on spectra here: :ref:`sphx_glr_generated_gallery_calibration_04_compare_cosmic_ray_backends.py`.
+``irispy`` supports two backends for cosmic ray removal, they are compared in this example: :ref:`sphx_glr_generated_gallery_calibration_04_compare_cosmic_ray_backends.py`.
 """
 
 import matplotlib.pyplot as plt
@@ -31,16 +31,20 @@ sji_filename = pooch.retrieve(
     "https://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2026/02/06/20260206_210853_3460104433/iris_l2_20260206_210853_3460104433_SJI_2832_t000.fits.gz",
     known_hash="d5088c6a0753ea9ce7b525865ba2edf13a637097ee995985b511833897c88ca6",
 )
+raster_filename = pooch.retrieve(
+    "https://www.lmsal.com/solarsoft/irisa/data/level2_compressed/2026/02/09/20260209_215233_3602506433/iris_l2_20260209_215233_3602506433_raster.tar.gz",
+    known_hash="bad4a3617d0fd04679203951d7db595df196f79b41a3f6f1f71ce0e301486434",
+)
+
 ###############################################################################
-# We will now open the file we just downloaded and select one frame.
-#
-# ``astroscrappy`` works on one 2D frame at a time. Selecting a single frame
-# keeps this example lightweight enough for documentation builds while still
-# demonstrating the same API.
+# We will now open the data using a helper function which is designed to read
+# all files from a single observation.
 
 sji_2832 = read_files(sji_filename)
-sji_frame = sji_2832[5]
-del sji_2832
+raster = read_files(raster_filename)
+raster_2796 = raster["Mg II k 2796"].raster_slice(10)[4]
+# Used to reduce memory usage for the online documentation build.
+del raster
 
 ###############################################################################
 # Now we use ``remove_cosmic_rays`` with the ``astroscrappy`` backend.
@@ -55,7 +59,7 @@ del sji_2832
 #
 # For more details on the parameters, see the `astroscrappy documentation <https://astroscrappy.readthedocs.io/en/latest/api/astroscrappy.detect_cosmics.html#astroscrappy.detect_cosmics>`__.
 
-sji_cleaned = sji_frame.remove_cosmic_rays(
+sji_cleaned = sji_2832.remove_cosmic_rays(
     method="astroscrappy",
     sigma=2,
     method_kwargs={"objlim": 2, "readnoise": 4},
@@ -63,24 +67,53 @@ sji_cleaned = sji_frame.remove_cosmic_rays(
 
 ###############################################################################
 # ``remove_cosmic_rays`` returns a cleaned cube with the same metadata and coordinates.
-# We now plot the noisy frame and the cleaned frame side-by-side.
+# We now convert a noisy frame to a map for plotting.
+
+sji_map = sji_2832.to_maps(5)
+clean_sji_map = sji_cleaned.to_maps(5)
 
 fig = plt.figure(figsize=(12, 5), constrained_layout=True)
 
-ax = fig.add_subplot(121, projection=sji_frame.wcs)
-sji_frame.plot(axes=ax, vmin=0, vmax=500)
+ax = fig.add_subplot(121, projection=sji_map)
+sji_map.plot(axes=ax, vmin=0, vmax=500)
 ax.set_title("Original")
 
-ax1 = fig.add_subplot(122, projection=sji_cleaned.wcs)
-sji_cleaned.plot(axes=ax1, vmin=0, vmax=500)
+ax1 = fig.add_subplot(122, projection=clean_sji_map)
+clean_sji_map.plot(axes=ax1, vmin=0, vmax=500)
 ax1.set_title("Cleaned")
 
 ax1.coords[1].set_ticks_visible(False)
 ax1.coords[1].set_ticklabel_visible(False)
 
 ###############################################################################
-# For any cosmic ray removal, it is important to check the results. These
-# methods are not perfect and can sometimes mark real features as cosmic ray
-# hits, especially if the parameters are not tuned for the specific data.
+# For comparison, we will now try to remove the cosmic ray hits from the
+# spectrograph data.
+
+raster_2796_cleaned = raster_2796.remove_cosmic_rays(method="astroscrappy")
+
+fig = plt.figure(figsize=(12, 5), constrained_layout=True)
+axes = [
+    fig.add_subplot(1, 2, 1, projection=raster_2796.wcs),
+    fig.add_subplot(1, 2, 2, projection=raster_2796_cleaned.wcs),
+]
+
+raster_2796.plot(axes=axes[0], vmin=0, vmax=500)
+axes[0].set_title("Original Mg II k 2796")
+
+raster_2796_cleaned.plot(axes=axes[1], vmin=0, vmax=500)
+axes[1].set_title("Cleaned Mg II k 2796")
+
+for ax in axes:
+    ax.set_xlabel("")
+    ax.set_ylabel("")
+    ax.set_xticks([])
+    ax.set_yticks([])
+
+###############################################################################
+# For any cosmic ray removal, it is important to check the results, especially
+# if you are interested in the spectral data. These methods are not perfect and
+# can sometimes mark real features as cosmic ray hits, especially if the
+# parameters are not tuned for the specific data. Always check the results
+# to ensure that important features are not being removed.
 
 plt.show()

--- a/examples/calibration/04_compare_cosmic_ray_backends.py
+++ b/examples/calibration/04_compare_cosmic_ray_backends.py
@@ -43,7 +43,7 @@ raster_filename = pooch.retrieve(
 
 raster = read_files(raster_filename)
 # Open the data and select one Si IV 1403 slice for the comparison.
-raster_1403 = raster["Si IV 1403"][10][4]
+raster_1403 = raster["Si IV 1403"].raster_slice(10)[4]
 del raster
 
 ###############################################################################

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -1,6 +1,10 @@
 import textwrap
 
 import matplotlib.pyplot as plt
+import numpy as np
+
+import astropy.units as u
+from astropy.wcs.utils import wcs_to_celestial_frame
 
 from ndcube import NDCollection
 from sunpy import log as logger
@@ -11,6 +15,9 @@ from irispy.utils.cosmic_rays import remove_cosmic_rays
 from irispy.visualization import IRISPlotter, finalize_iris_plot
 
 __all__ = ["RasterCollection", "SpectrogramCube"]
+
+RASTER_SEGMENT_STEP_SEARCH_RADIUS = 2
+RASTER_SEGMENT_SLIT_SEARCH_RADIUS = 16
 
 
 class SpectrogramCube(_SpectrogramCubeWCSMixin, SpecCube):
@@ -164,6 +171,130 @@ class SpectrogramCube(_SpectrogramCubeWCSMixin, SpecCube):
         if not boundaries:
             return (self,)
         return tuple(self[raster_slice] for raster_slice in boundaries)
+
+    def _search_segment_grid(self, segment_cube, target, step_indices, slit_indices):
+        """Evaluate the gWCS over a grid and return the pixel nearest to *target*."""
+        step_grid, slit_grid = np.meshgrid(step_indices, slit_indices, indexing="ij")
+        sky = segment_cube.wcs.array_index_to_world(step_grid, slit_grid, np.zeros_like(step_grid))[1]
+        separation = sky.separation(target.transform_to(sky.frame)).to_value(u.arcsec)
+        local = np.unravel_index(np.nanargmin(separation), separation.shape)
+        return float(separation[local]), int(step_grid[local]), int(slit_grid[local])
+
+    def _nearest_raster_segment(self, target, *, clip):
+        if not self._raster_boundaries:
+            return None
+
+        best_match = None
+        for segment_index, raster_slice in enumerate(self.raster_boundaries):
+            segment_cube = self[raster_slice]
+            if segment_cube.basic_wcs is not None:
+                guess_target = target.transform_to(wcs_to_celestial_frame(segment_cube.basic_wcs.celestial))
+                step_guess, slit_guess = segment_cube.basic_wcs.celestial.world_to_array_index(guess_target)
+                guess_valid = (
+                    np.isfinite(step_guess)
+                    and np.isfinite(slit_guess)
+                    and 0 <= step_guess < segment_cube.shape[0]
+                    and 0 <= slit_guess < segment_cube.shape[1]
+                )
+                if guess_valid:
+                    step_guess = int(np.rint(np.clip(step_guess, 0, segment_cube.shape[0] - 1)))
+                    slit_guess = int(np.rint(np.clip(slit_guess, 0, segment_cube.shape[1] - 1)))
+                    step_indices = np.arange(
+                        max(0, step_guess - RASTER_SEGMENT_STEP_SEARCH_RADIUS),
+                        min(segment_cube.shape[0], step_guess + RASTER_SEGMENT_STEP_SEARCH_RADIUS + 1),
+                        dtype=int,
+                    )
+                    slit_indices = np.arange(
+                        max(0, slit_guess - RASTER_SEGMENT_SLIT_SEARCH_RADIUS),
+                        min(segment_cube.shape[1], slit_guess + RASTER_SEGMENT_SLIT_SEARCH_RADIUS + 1),
+                        dtype=int,
+                    )
+                    score, step, slit = self._search_segment_grid(segment_cube, target, step_indices, slit_indices)
+                    if best_match is None or score < best_match[0]:
+                        best_match = (score, segment_index, step, slit)
+                    continue
+                if not clip:
+                    continue
+
+            step_indices = np.arange(segment_cube.shape[0], dtype=int)
+            slit_indices = np.arange(segment_cube.shape[1], dtype=int)
+            score, step, slit = self._search_segment_grid(segment_cube, target, step_indices, slit_indices)
+            if best_match is None or score < best_match[0]:
+                best_match = (score, segment_index, step, slit)
+
+        if best_match is None:
+            if clip:
+                return None
+            msg = "Target is outside the raster bounds."
+            raise ValueError(msg)
+        return best_match
+
+    def _crop_spectrum_at_pixel(self, cube, step_index, slit_index):
+        """Extract a 1D spectrum from *cube* at the given pixel."""
+        start = cube.wcs.array_index_to_world(step_index, slit_index, 0)
+        stop = cube.wcs.array_index_to_world(step_index, slit_index, cube.shape[-1] - 1)
+        return cube.crop(start, stop)
+
+    def spectrum_at(self, target, *, clip=True):
+        """
+        Return the spectrum at the raster pixel nearest a sky coordinate.
+
+        Parameters
+        ----------
+        target : `astropy.coordinates.SkyCoord`
+            Sky coordinate to sample.
+        clip : `bool`, optional
+            If `True`, off-raster targets are clipped to the nearest edge pixel.
+            If `False`, out-of-bounds targets raise `ValueError`.
+
+        Returns
+        -------
+        `irispy.spectrograph.SpectrogramCube`
+            One-dimensional spectrum extracted from the nearest raster pixel.
+        """
+        if self.data.ndim != 3:
+            msg = "spectrum_at requires a 3D raster cube."
+            raise ValueError(msg)
+
+        if self.basic_wcs is not None:
+            target_in_frame = target.transform_to(wcs_to_celestial_frame(self.basic_wcs.celestial))
+            step_index, slit_index = self.basic_wcs.celestial.world_to_array_index(target_in_frame)
+            if clip:
+                step_index = int(np.rint(np.clip(step_index, 0, self.shape[0] - 1)))
+                slit_index = int(np.rint(np.clip(slit_index, 0, self.shape[1] - 1)))
+            else:
+                step_index = int(np.rint(step_index))
+                slit_index = int(np.rint(slit_index))
+                if not (0 <= step_index < self.shape[0] and 0 <= slit_index < self.shape[1]):
+                    nearest_segment = self._nearest_raster_segment(target, clip=clip)
+                    if nearest_segment is not None:
+                        _, nearest_segment_index, step_index, slit_index = nearest_segment
+                        return self._crop_spectrum_at_pixel(self.raster_slice(nearest_segment_index), step_index, slit_index)
+                    msg = "Target is outside the raster bounds."
+                    raise ValueError(msg)
+            return self._crop_spectrum_at_pixel(self, step_index, slit_index)
+
+        nearest_segment = self._nearest_raster_segment(target, clip=clip)
+        if nearest_segment is not None:
+            _, nearest_segment_index, step_index, slit_index = nearest_segment
+            return self._crop_spectrum_at_pixel(self.raster_slice(nearest_segment_index), step_index, slit_index)
+
+        sky_grid = self.axis_world_coords("custom:pos.helioprojective.lon", "custom:pos.helioprojective.lat")[0]
+        target_in_frame = target.transform_to(sky_grid.frame)
+        if not clip:
+            lon = target_in_frame.Tx.to(u.arcsec)
+            lat = target_in_frame.Ty.to(u.arcsec)
+            if (
+                lon < np.nanmin(sky_grid.Tx)
+                or lon > np.nanmax(sky_grid.Tx)
+                or lat < np.nanmin(sky_grid.Ty)
+                or lat > np.nanmax(sky_grid.Ty)
+            ):
+                msg = "Target is outside the raster bounds."
+                raise ValueError(msg)
+        separation = sky_grid.separation(target_in_frame)
+        step_index, slit_index = np.unravel_index(np.nanargmin(separation.to_value(u.arcsec)), separation.shape)
+        return self._crop_spectrum_at_pixel(self, step_index, slit_index)
 
     def remove_cosmic_rays(
         self,

--- a/irispy/tests/test_spectrograph.py
+++ b/irispy/tests/test_spectrograph.py
@@ -12,6 +12,8 @@ from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
 
 from ndcube.utils.exceptions import NDCubeUserWarning
+from sunpy.coordinates import HeliographicStonyhurst
+from sunpy.coordinates.screens import SphericalScreen
 
 from irispy.io._raster_combine import _lazy_raster_scan_chunk_rows
 from irispy.io.spectrograph import read_spectrograph_lvl2
@@ -126,6 +128,21 @@ def test_spectrogram_cube_crop_slices_basic_wcs(raster_sg_files):
     assert_quantity_allclose(image_sky.Ty.to(u.arcsec), expected_sky.Ty.to(u.arcsec))
 
 
+def test_spectrogram_cube_spectrum_at_returns_nearest_raster_spectrum(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"]
+    _, target, _, _ = cube.wcs.array_index_to_world(3, 50, 10)
+
+    expected = cube.crop(
+        cube.wcs.array_index_to_world(3, 50, 0),
+        cube.wcs.array_index_to_world(3, 50, cube.shape[-1] - 1),
+    )
+    spectrum = cube.spectrum_at(target)
+
+    assert spectrum.shape == expected.shape
+    np.testing.assert_array_equal(spectrum.data, expected.data)
+
+
 def test_spectrogram_cube_exposes_raster_grouping_helpers(raster_sg_files):
     raster = read_spectrograph_lvl2(raster_sg_files)
     cube = raster["Si IV 1403"]
@@ -151,6 +168,63 @@ def test_spectrogram_cube_supports_crop_apis(raster_sg_files):
 
     assert spectrum.data.ndim == 1
     assert spectrum_by_values.data.ndim == 1
+
+
+def test_spectrogram_cube_spectrum_at_works_without_basic_wcs(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"]
+    _, target, _, _ = cube.wcs.array_index_to_world(10, 50, 0)
+
+    expected = cube.crop(
+        cube.wcs.array_index_to_world(10, 50, 0),
+        cube.wcs.array_index_to_world(10, 50, cube.shape[-1] - 1),
+    )
+    spectrum = cube.spectrum_at(target)
+
+    assert cube.basic_wcs is None
+    assert spectrum.shape == expected.shape
+    np.testing.assert_array_equal(spectrum.data, expected.data)
+
+
+def test_spectrogram_cube_spectrum_at_transforms_target_frame(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"]
+    _, target, _, _ = cube.wcs.array_index_to_world(10, 50, 0)
+    expected = cube.spectrum_at(target)
+
+    with SphericalScreen(target.observer):
+        transformed_target = target.transform_to(HeliographicStonyhurst(obstime=target.obstime))
+
+    spectrum = cube.spectrum_at(transformed_target)
+
+    assert cube.basic_wcs is None
+    assert spectrum.shape == expected.shape
+    np.testing.assert_array_equal(spectrum.data, expected.data)
+
+
+def test_spectrogram_cube_spectrum_at_combined_raster_clip_false_raises(raster_sg_files):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"]
+    _, target, _, _ = cube.wcs.array_index_to_world(10, 50, 0)
+    outside_target = target.spherical_offsets_by(1000 * u.arcsec, 1000 * u.arcsec)
+
+    with pytest.raises(ValueError, match="Target is outside the raster bounds"):
+        cube.spectrum_at(outside_target, clip=False)
+
+
+def test_spectrogram_cube_spectrum_at_avoids_full_sky_grid_when_segment_wcs_exists(raster_sg_files, monkeypatch):
+    raster = read_spectrograph_lvl2(raster_sg_files)
+    cube = raster["Si IV 1403"]
+    _, target, _, _ = cube.wcs.array_index_to_world(10, 50, 0)
+
+    def fail_axis_world_coords(*_args, **_kwargs):
+        msg = "full sky grid lookup should not be used"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(cube, "axis_world_coords", fail_axis_world_coords)
+    spectrum = cube.spectrum_at(target)
+
+    assert spectrum.shape == (cube.shape[-1],)
 
 
 def test_spectrogram_cube_scan_slice_recovers_segment_basic_wcs(raster_sg_files):
@@ -185,6 +259,8 @@ def test_memmap_split_rasters_returns_lazy_subcubes(raster_sg_files):
 def test_memmap_raster_returns_lazy_combined_cube(raster_sg_files):
     raster = read_spectrograph_lvl2(raster_sg_files, memmap=True, uncertainty=True)
     cube = raster["Si IV 1403"]
+    _, target, _, _ = cube.wcs.array_index_to_world(10, 50, 0)
+    spectrum = cube.spectrum_at(target)
     image = cube.crop(
         [SpectralCoord(cube.spectral_axis[len(cube.spectral_axis) // 2]), None, None, None],
         [SpectralCoord(cube.spectral_axis[len(cube.spectral_axis) // 2]), None, None, None],
@@ -196,6 +272,7 @@ def test_memmap_raster_returns_lazy_combined_cube(raster_sg_files):
     assert len(cube.raster_boundaries) == 13
     assert cube.basic_wcs is None
     assert cube.uncertainty is None
+    assert spectrum.data.ndim == 1
     assert image.data.ndim == 2
 
 
@@ -211,6 +288,10 @@ def test_memmap_raster_values_match_raw_fits_after_reader_returns(raster_sg_file
 
     np.testing.assert_array_equal(raster0.data.compute(), expected_data)
     np.testing.assert_array_equal(raster0.mask.compute(), expected_data == BAD_PIXEL_VALUE_UNSCALED)
+
+    _, target, _, _ = raster0.wcs.array_index_to_world(3, 50, 0)
+    spectrum = cube.spectrum_at(target)
+    np.testing.assert_array_equal(spectrum.data.compute(), expected_data[3, 50])
 
 
 def test_memmap_raster_uses_subfile_scan_chunks(raster_sg_files):


### PR DESCRIPTION
## Summary by Sourcery

Add support for extracting a 1D spectrum from a raster cube at the pixel nearest to a given sky coordinate, including for combined and memmapped rasters.

New Features:
- Introduce SpectrogramCube.spectrum_at to return a one-dimensional spectrum at the raster pixel nearest a given sky coordinate, with optional clipping for out-of-bounds targets.

Enhancements:
- Optimize nearest-pixel lookup across raster segments by preferring segment-level WCS over a full sky-grid search when available.

Documentation:
- Add a changelog entry describing the new raster spectrum lookup capability.

Tests:
- Add tests covering spectrum_at behavior with and without basic WCS, across different coordinate frames, for out-of-bounds handling, and for combined and memmapped rasters.