### PR TITLE
Cleanup RBAs and Moments

### DIFF
--- a/changelog/140.breaking.rst
+++ b/changelog/140.breaking.rst
@@ -1,0 +1,3 @@
+``calculate_red_blue_asymmetry`` now takes ``degree`` (int) instead of ``interpolation_kind``
+(str), ``mask_negative`` is removed (negatives are always masked), and ``rest_wavelength``
+defaults to ``None`` (auto-detected from cube metadata).

--- a/changelog/140.breaking.rst
+++ b/changelog/140.breaking.rst
@@ -1,3 +1,3 @@
-``calculate_red_blue_asymmetry`` now takes ``degree`` (int) instead of ``interpolation_kind``
-(str), ``mask_negative`` is removed (negatives are always masked), and ``rest_wavelength``
-defaults to ``None`` (auto-detected from cube metadata).
+`irispy.utils.calculate_red_blue_asymmetry` now takes ``degree`` instead of ``interpolation_kind``.
+Removed ``mask_negative`` as it is now always masked.
+``rest_wavelength`` defaults to ``None`` as we now get the value from the cube metadata.

--- a/changelog/140.feature.rst
+++ b/changelog/140.feature.rst
@@ -1,2 +1,2 @@
-Add ``rest_wavelength`` and ``detector_band`` properties to metadata classes, and
-``spectral_dispersion`` and ``solid_angle`` properties to ``SpectrogramCube``.
+Add ``rest_wavelength`` and ``detector_band`` properties to the metadata.
+Add ``spectral_dispersion`` and ``solid_angle`` properties to ``SpectrogramCube``.

--- a/changelog/140.feature.rst
+++ b/changelog/140.feature.rst
@@ -1,0 +1,2 @@
+Add ``rest_wavelength`` and ``detector_band`` properties to metadata classes, and
+``spectral_dispersion`` and ``solid_angle`` properties to ``SpectrogramCube``.

--- a/examples/analysis/05_red_blue_asymmetry.py
+++ b/examples/analysis/05_red_blue_asymmetry.py
@@ -20,7 +20,7 @@ import astropy.units as u
 from astropy.visualization import time_support
 
 from irispy.io import read_files
-from irispy.utils.red_blue import calculate_red_blue_asymmetry
+from irispy.utils.red_blue import RBAQualityFlag, calculate_red_blue_asymmetry
 
 time_support()
 
@@ -64,9 +64,10 @@ velocity_range = (25, 75) * u.km / u.s
 # Ignore pixels where the line peak is too weak for a useful wing comparison.
 min_intensity = 75 * si_iv.unit
 
+# rest_wavelength is auto-detected from the cube metadata (TWAVE[N] FITS keyword).
+# You can also pass it explicitly: rest_wavelength=si_iv_rest.
 red_blue = calculate_red_blue_asymmetry(
     si_iv,
-    rest_wavelength=si_iv_rest,
     velocity_range=velocity_range,
     min_intensity=min_intensity,
     return_profiles=True,
@@ -102,7 +103,8 @@ axes = [
 
 # This plot will be the RBA values over the full raster.
 ax = axes[0]
-rba_map = np.where(quality.data == 0, asymmetry.data, np.nan)
+rba_map = np.where(quality.data == int(RBAQualityFlag.OK), asymmetry.data, np.nan)
+# Colour scale: 98th percentile of absolute RBA, floored so subtle features remain visible.
 vmax = max(np.nanpercentile(np.abs(rba_map), 98), 0.15)
 im = ax.imshow(rba_map, cmap="RdBu_r", origin="lower", aspect="auto", vmin=-vmax, vmax=vmax)
 ax.plot(

--- a/irispy/meta.py
+++ b/irispy/meta.py
@@ -69,6 +69,21 @@ class BaseMeta(NDMeta):
         return self._construct_time("DATE_END")
 
     @property
+    def temporal_cadence(self):
+        """
+        Average time between exposures along the first axis.
+        """
+        date_start = self.date_start
+        date_end = self.date_end
+        if date_start is None or date_end is None:
+            return None
+        duration = (date_end - date_start).to(u.s)
+        n_frames = self.data_shape[0] if len(self.data_shape) > 0 else None
+        if n_frames is None or n_frames <= 1:
+            return None
+        return duration / (n_frames - 1)
+
+    @property
     def observing_mode_id(self):
         return int(self.get("OBSID"))
 
@@ -146,6 +161,33 @@ class BaseMeta(NDMeta):
         The spectral band of the spectral window.
         """
         return SPECTRAL_BAND.get(self.spectral_window, self.spectral_window)
+
+    @property
+    def detector_band(self):
+        """
+        Normalized detector band: ``'FUV'``, ``'NUV'``, or ``'SJI'``.
+
+        Derived from :attr:`detector` by stripping the trailing digit (e.g. ``'FUV2'`` →
+        ``'FUV'``). For non-IRIS detectors the original string is returned unchanged.
+        """
+        det = self.detector
+        if det is None:
+            return None
+        det_upper = det.upper()
+        for band in ("FUV", "NUV", "SJI"):
+            if det_upper.startswith(band):
+                return band
+        return det
+
+    @property
+    def rest_wavelength(self):
+        """
+        Rest wavelength of the spectral line for this window.
+
+        Read from the ``TWAVE<n>`` FITS keyword and returned in nm.
+        """
+        value = self.get(f"TWAVE{self._iwin}")
+        return (value * u.AA).to(u.nm)
 
     @property
     def raster_fov_width_y(self):

--- a/irispy/spectrograph.py
+++ b/irispy/spectrograph.py
@@ -3,11 +3,15 @@ import textwrap
 import matplotlib.pyplot as plt
 import numpy as np
 
+import astropy.units as u
+
 from ndcube import NDCollection
+from ndcube.wcs.tools import unwrap_wcs_to_fitswcs
 from sunpy import log as logger
 from sunraster import SpectrogramCube as SpecCube
 from sunraster import SpectrogramSequence as SpecSeq
 
+from irispy.utils.constants import SLIT_WIDTH
 from irispy.utils.cosmic_rays import remove_cosmic_rays
 from irispy.visualization import IRISPlotter, IRISSequencePlotter, set_axis_properties
 
@@ -143,6 +147,43 @@ class SpectrogramCube(SpecCube):
             sigma=sigma,
             max_iters=max_iters,
             method_kwargs=method_kwargs,
+        )
+
+    @property
+    def spectral_dispersion(self):
+        """
+        Spectral dispersion per pixel along the wavelength axis.
+        """
+        wcs = unwrap_wcs_to_fitswcs(self.wcs)[0].wcs if not hasattr(self.wcs, "wcs") else self.wcs.wcs
+        mask = np.array([ctype == "WAVE" for ctype in wcs.ctype])
+        if not mask.any():
+            msg = "Cannot determine spectral axis (no WAVE ctype in WCS) for spectral_dispersion"
+            raise ValueError(msg)
+        idx = np.argmax(mask)
+        return wcs.cdelt[idx] * u.Unit(wcs.cunit[idx])
+
+    @property
+    def solid_angle(self):
+        """
+        Solid angle per spatial pixel (slit width x spatial pixel scale).
+        """
+        wcs = unwrap_wcs_to_fitswcs(self.wcs)[0].wcs if not hasattr(self.wcs, "wcs") else self.wcs.wcs
+        mask = np.array(["HPLT" in ctype for ctype in wcs.ctype])
+        if not mask.any():
+            msg = "Cannot determine latitude axis (no HPLT ctype in WCS) for solid_angle computation"
+            raise ValueError(msg)
+        lat_idx = np.argmax(mask)
+        return wcs.cdelt[lat_idx] * u.Unit(wcs.cunit[lat_idx]) * SLIT_WIDTH
+
+    @property
+    def wavelength_axis(self):
+        """
+        Index of the spectral (wavelength) axis.
+        """
+        return next(
+            axis
+            for axis, physical_types in enumerate(self.array_axis_physical_types)
+            if physical_types and "em.wl" in physical_types
         )
 
 

--- a/irispy/tests/test_meta.py
+++ b/irispy/tests/test_meta.py
@@ -1,0 +1,188 @@
+import numpy as np
+import pytest
+
+import astropy.units as u
+from astropy.io import fits
+from astropy.time import Time
+from astropy.wcs import WCS
+
+from irispy.io.utils import read_files
+from irispy.meta import SGMeta, SJIMeta
+from irispy.spectrograph import SpectrogramCube
+from irispy.tests.helpers import make_test_spectrogram_cube
+from irispy.utils.constants import SLIT_WIDTH
+
+
+def _make_sg_header():
+    header = fits.Header()
+    header["INSTRUME"] = "IRIS"
+    header["TELESCOP"] = "IRIS"
+    header["DATA_LEV"] = 2
+    header["OBSID"] = 1
+    header["OBS_DESC"] = "Test obs"
+    header["NWIN"] = 1
+    header["TDESC1"] = "Si IV 1403"
+    header["TWAVE1"] = 1402.77
+    header["TWMIN1"] = 1398.61
+    header["TWMAX1"] = 1406.03
+    header["TDET1"] = "FUV2"
+    return header
+
+
+def test_sgmeta_rest_wavelength():
+    meta = SGMeta(_make_sg_header(), "Si IV 1403")
+    assert meta.rest_wavelength.unit == u.nm
+    assert u.isclose(meta.rest_wavelength, 140.277 * u.nm, rtol=1e-4)
+
+
+def test_sgmeta_rest_wavelength_no_twave():
+    header = _make_sg_header()
+    del header["TWAVE1"]
+    meta = SGMeta(header, "Si IV 1403")
+    with pytest.raises((KeyError, TypeError)):
+        _ = meta.rest_wavelength
+
+
+def test_sgmeta_detector_band_fuv():
+    meta = SGMeta(_make_sg_header(), "Si IV 1403")
+    assert meta.detector_band == "FUV"
+
+
+def test_sgmeta_detector_band_nuv():
+    header = _make_sg_header()
+    header["TDET1"] = "NUV"
+    meta = SGMeta(header, "Si IV 1403")
+    assert meta.detector_band == "NUV"
+
+
+def test_sgmeta_detector_band_sji():
+    header = fits.Header()
+    header["INSTRUME"] = "IRIS"
+    header["TELESCOP"] = "IRIS"
+    header["TDET1"] = "SJI"
+    header["TDESC1"] = "SJI_1330"
+    header["TWAVE1"] = 1330.0
+    header["TWMIN1"] = 1330.0
+    header["TWMAX1"] = 1330.0
+    meta = SJIMeta(header)
+    assert meta.detector_band == "SJI"
+
+
+def test_spectral_dispersion():
+    wavelengths = np.arange(10) * 0.02 * u.nm + 140 * u.nm
+    cube = make_test_spectrogram_cube(np.ones((1, 1, 10)), wavelengths)
+    dispersion = cube.spectral_dispersion
+    assert dispersion.unit.is_equivalent(u.nm)
+    assert u.isclose(dispersion, 0.02 * u.nm, rtol=0.01)
+
+
+def test_solid_angle():
+    wavelengths = np.arange(10) * 0.02 * u.nm + 140 * u.nm
+    cube = make_test_spectrogram_cube(np.ones((1, 1, 10)), wavelengths)
+    angle = cube.solid_angle
+    assert angle.unit.is_equivalent(u.sr)
+    expected = 1.0 * u.arcsec * SLIT_WIDTH
+    assert u.isclose(angle.to(u.sr), expected.to(u.sr), rtol=0.01)
+
+
+@pytest.mark.parametrize(
+    ("date_start", "date_end", "n_frames", "expect_none"),
+    [
+        (None, "2013-07-24T00:00:09.000", 10, True),
+        ("2013-07-24T00:00:00.000", None, 10, True),
+        ("2013-07-24T00:00:00.000", "2013-07-24T00:00:09.000", 1, True),
+        ("2013-07-24T00:00:00.000", "2013-07-24T00:00:09.000", 10, False),
+    ],
+)
+def test_sgmeta_temporal_cadence(date_start, date_end, n_frames, expect_none):
+    header = _make_sg_header()
+    if date_start is not None:
+        header["DATE_OBS"] = date_start
+    if date_end is not None:
+        header["DATE_END"] = date_end
+    meta = SGMeta(header, "Si IV 1403", data_shape=(n_frames, 2, 2))
+    cadence = meta.temporal_cadence
+    if expect_none:
+        assert cadence is None
+    else:
+        assert cadence is not None
+        start = Time(date_start)
+        end = Time(date_end)
+        expected = (end - start) / (n_frames - 1)
+        assert u.allclose(cadence.to(u.s), expected.to(u.s), rtol=0, atol=1e-6 * u.s)
+
+
+def test_spectral_dispersion_missing_wave_raises():
+    header = fits.Header()
+    header["NAXIS"] = 2
+    header["NAXIS1"] = 5
+    header["NAXIS2"] = 2
+    header["CTYPE1"] = "HPLT-TAN"
+    header["CTYPE2"] = "HPLN-TAN"
+    header["CDELT1"] = 0.1
+    header["CRVAL1"] = 0
+    header["CRPIX1"] = 1
+    header["CUNIT1"] = "arcsec"
+    header["CDELT2"] = 0.1
+    header["CRVAL2"] = 0
+    header["CRPIX2"] = 1
+    header["CUNIT2"] = "arcsec"
+    wcs = WCS(header)
+    cube = SpectrogramCube(np.ones((2, 5)), wcs=wcs, uncertainty=None, unit=u.DN, meta={}, mask=None)
+    with pytest.raises(ValueError, match="no WAVE ctype"):
+        _ = cube.spectral_dispersion
+
+
+def test_solid_angle_missing_hplt_raises():
+    header = fits.Header()
+    header["NAXIS"] = 3
+    header["NAXIS1"] = 5
+    header["NAXIS2"] = 2
+    header["NAXIS3"] = 1
+    header["CTYPE1"] = "WAVE"
+    header["CTYPE2"] = "TIME"
+    header["CTYPE3"] = "UTC"
+    header["CDELT1"] = 0.02
+    header["CRVAL1"] = 140.0
+    header["CRPIX1"] = 1
+    header["CUNIT1"] = "nm"
+    header["CDELT2"] = 1.0
+    header["CRVAL2"] = 0
+    header["CRPIX2"] = 1
+    header["CUNIT2"] = "s"
+    header["CDELT3"] = 1.0
+    header["CRVAL3"] = 0
+    header["CRPIX3"] = 1
+    header["CUNIT3"] = "s"
+    wcs = WCS(header)
+    cube = SpectrogramCube(np.ones((1, 2, 5)), wcs=wcs, uncertainty=None, unit=u.DN, meta={}, mask=None)
+    with pytest.raises(ValueError, match="no HPLT ctype"):
+        _ = cube.solid_angle
+
+
+def test_sgmeta_real_sns_data(sns_sg_file):
+    raster = read_files(sns_sg_file)
+    cube = raster["Si IV 1403"][0]
+    meta = cube.meta
+
+    assert meta.detector_band == "FUV"
+    assert meta.rest_wavelength.unit == u.nm
+    assert u.isclose(meta.rest_wavelength, 140.277 * u.nm, rtol=1e-3)
+    assert meta.temporal_cadence is not None
+    assert meta.temporal_cadence.unit.is_equivalent(u.s)
+
+
+def test_spectral_dispersion_real_data(sns_sg_file):
+    raster = read_files(sns_sg_file)
+    cube = raster["Si IV 1403"][0]
+    dispersion = cube.spectral_dispersion
+    assert dispersion.unit.is_equivalent(u.nm)
+    assert dispersion.value > 0
+
+
+def test_solid_angle_real_data(sns_sg_file):
+    raster = read_files(sns_sg_file)
+    cube = raster["Si IV 1403"][0]
+    angle = cube.solid_angle
+    assert angle.unit.is_equivalent(u.sr)
+    assert angle.value > 0

--- a/irispy/utils/moments.py
+++ b/irispy/utils/moments.py
@@ -1,6 +1,8 @@
 """
-This module provides spectral moment calculation utilities for IRIS spectrogram cubes.
+Spectral moment calculation utilities for IRIS spectrogram cubes.
 """
+
+import contextlib
 
 import numpy as np
 
@@ -30,8 +32,6 @@ def _parse_wings(wings):
     raise TypeError(msg)
 
 
-# NOTE: We do not use @u.quantity_input because it cannot validate tuple
-# Quantities like ``(0.05, 0.15) * u.Angstrom`` for the ``wings`` argument.
 def calculate_moments(
     cube, *, rest_wavelength=None, wings=None, integrated=False, min_intensity=None, saturation_limit=None
 ):
@@ -50,7 +50,10 @@ def calculate_moments(
     cube : `irispy.spectrograph.SpectrogramCube`
         The input data cube. Must have a spectral (wavelength) axis.
     rest_wavelength : `astropy.units.Quantity`, optional
-        The rest wavelength of the spectral line. Required if ``wings`` is given.
+        The rest wavelength of the spectral line. If omitted, read from
+        ``cube.meta.rest_wavelength`` (requires an `~irispy.meta.SGMeta`
+        instance with a ``TWAVE<n>`` FITS keyword). Required if ``wings``
+        is given and no rest wavelength can be auto-detected.
     wings : `astropy.units.Quantity`, optional
         The spectral range around ``rest_wavelength`` to include in the calculation.
         Must be an `~astropy.units.Quantity` with appropriate units (e.g., nm or Angstrom).
@@ -61,15 +64,12 @@ def calculate_moments(
         with units of ``DN·nm``. If `False` (default), it is computed as :math:`\sum I(\lambda)`
         with units of ``DN`` (i.e., per-pixel sum, matching the convention used in
         Gaussian fitting).
-    min_intensity : `float`, optional
+    min_intensity : `float` or `astropy.units.Quantity`, optional
         Minimum integrated (or per-pixel) intensity required for a pixel to be
-        considered valid. Pixels with intensity **below** this value have all
-        their moments (including intensity) set to NaN. Useful for excluding
-        noisy low-signal pixels.
-    saturation_limit : `float`, optional
-        Maximum allowed peak intensity in any spectral bin. Pixels where any
-        bin in the (cropped) profile exceeds this value are treated as
-        saturated and have all their moments set to NaN.
+        considered valid. Pixels below this value have all moments set to NaN.
+    saturation_limit : `float` or `astropy.units.Quantity`, optional
+        Maximum allowed peak intensity in any spectral bin. Pixels exceeding
+        this value have all moments set to NaN.
 
     Returns
     -------
@@ -83,14 +83,14 @@ def calculate_moments(
         * ``"centroid"`` — 1st moment (centroid wavelength)
         * ``"width"`` — 2nd moment (standard deviation)
 
-        Additionally, if ``rest_wavelength`` is provided:
+        Additionally, if ``rest_wavelength`` is known:
 
         * ``"velocity"`` — Doppler shift from the centroid in km/s
         * ``"velocity_width"`` — line width converted to velocity units in km/s
 
     Notes
     -----
-    * Negative and non-finite (NaN/inf) data values are set to zero before computing moments.
+    * Negative and non-finite data values are set to zero before computing moments.
     * Wavelength coordinates are converted to **nm** internally, so ``centroid`` and ``width``
       are always returned in nm.
     * For a uniform spectral grid, the 1st and 2nd moments are identical regardless of the
@@ -102,13 +102,12 @@ def calculate_moments(
     * `arXiv:2005.02029, Section 3.1 <https://arxiv.org/abs/2005.02029>`__
     * `Færder et al. (2024), ApJ, Appendix C <https://iopscience.iop.org/article/10.3847/1538-4357/ac4223>`__
     """
+    if rest_wavelength is None:
+        with contextlib.suppress(AttributeError, TypeError):
+            rest_wavelength = cube.meta.rest_wavelength
     try:
-        wavelength_axis = next(
-            axis
-            for axis, physical_types in enumerate(cube.array_axis_physical_types)
-            if physical_types and "em.wl" in physical_types
-        )
-    except StopIteration as exc:
+        wavelength_axis = cube.wavelength_axis
+    except (AttributeError, StopIteration) as exc:
         msg = "Could not identify a spectral wavelength axis on the input cube"
         raise ValueError(msg) from exc
     wavelengths = cube.axis_world_coords(wavelength_axis)[0]
@@ -119,7 +118,7 @@ def calculate_moments(
     mask = None if cube.mask is None else np.asarray(cube.mask, dtype=bool)
     if wings is not None:
         if rest_wavelength is None:
-            msg = "rest_wavelength must be provided when wings is given"
+            msg = "rest_wavelength must be provided (or detectable from cube metadata) when wings is given"
             raise ValueError(msg)
         rest_wavelength = u.Quantity(rest_wavelength)
         wing_low, wing_high = _parse_wings(wings)
@@ -141,32 +140,27 @@ def calculate_moments(
     if mask is not None:
         data[mask] = 0
     data[(data < 0) | ~np.isfinite(data)] = 0
-    # Calculate wavelength step (assumed uniform)
+
     dwvl = np.mean(np.diff(wavelengths))
-    # Move wavelength axis to the end for vectorised computation
     data_moved = np.moveaxis(data, wavelength_axis, -1)
     wvls = wavelengths.value
-    # Broadcast wavelengths to match moved data shape
     broadcast_shape = [1] * data_moved.ndim
     broadcast_shape[-1] = -1
     wvls_broadcast = wvls.reshape(broadcast_shape)
     dwvl_value = dwvl.value
-    # Weights for moment calculation: integrated (x dλ) or per-pixel
+
     if integrated:
         weights = data_moved * dwvl_value
         intensity_unit = cube.unit * dwvl.unit
     else:
         weights = data_moved
         intensity_unit = cube.unit
-    # 0th moment
+
     intensity_value = np.nansum(weights, axis=-1)
-    # 1st and 2nd moments are ratios where the weighting cancels out,
-    # so the result is the same for uniform dλ regardless of ``integrated``.
     intensity_nonzero = intensity_value != 0
     centroid_numerator = np.nansum(weights * wvls_broadcast, axis=-1)
     with np.errstate(invalid="ignore"):
         centroid_value = np.where(intensity_nonzero, centroid_numerator / intensity_value, np.nan)
-    # 2nd moment (variance)
     variance_numerator = np.nansum(((wvls_broadcast - centroid_value[..., np.newaxis]) ** 2) * weights, axis=-1)
     with np.errstate(invalid="ignore"):
         variance_value = np.where(intensity_nonzero, variance_numerator / intensity_value, np.nan)
@@ -174,37 +168,29 @@ def calculate_moments(
     stddev_value = np.sqrt(variance_value)
 
     if min_intensity is not None:
-        if isinstance(min_intensity, u.Quantity):
-            min_intensity_value = min_intensity.to_value(intensity_unit)
-        else:
-            min_intensity_value = min_intensity
+        min_intensity_value = (
+            min_intensity.to_value(intensity_unit) if isinstance(min_intensity, u.Quantity) else min_intensity
+        )
         low_intensity = intensity_value < min_intensity_value
         intensity_value = np.where(low_intensity, np.nan, intensity_value)
         centroid_value = np.where(low_intensity, np.nan, centroid_value)
         stddev_value = np.where(low_intensity, np.nan, stddev_value)
 
     if saturation_limit is not None:
-        peak_value = np.max(data_moved, axis=-1)
-        if isinstance(saturation_limit, u.Quantity):
-            saturation_limit_value = saturation_limit.to_value(cube.unit)
-        else:
-            saturation_limit_value = saturation_limit
-        saturated = peak_value > saturation_limit_value
+        saturation_limit_value = (
+            saturation_limit.to_value(cube.unit) if isinstance(saturation_limit, u.Quantity) else saturation_limit
+        )
+        saturated = np.max(data_moved, axis=-1) > saturation_limit_value
         intensity_value = np.where(saturated, np.nan, intensity_value)
         centroid_value = np.where(saturated, np.nan, centroid_value)
         stddev_value = np.where(saturated, np.nan, stddev_value)
 
     template = make_spatial_template(cube, wavelength_axis)
-
-    intensity_cube = make_map_cube(template, intensity_value, intensity_unit, mask_invalid=True)
-    centroid_cube = make_map_cube(template, centroid_value, wavelengths.unit, mask_invalid=True)
-    width_cube = make_map_cube(template, stddev_value, wavelengths.unit, mask_invalid=True)
     cubes = [
-        ("intensity", intensity_cube),
-        ("centroid", centroid_cube),
-        ("width", width_cube),
+        ("intensity", make_map_cube(template, intensity_value, intensity_unit, mask_invalid=True)),
+        ("centroid", make_map_cube(template, centroid_value, wavelengths.unit, mask_invalid=True)),
+        ("width", make_map_cube(template, stddev_value, wavelengths.unit, mask_invalid=True)),
     ]
-    # Compute velocity equivalents when rest_wavelength is known
     if rest_wavelength is not None:
         rest_wavelength = u.Quantity(rest_wavelength)
         with np.errstate(invalid="ignore"):
@@ -218,9 +204,13 @@ def calculate_moments(
                 / rest_wavelength
                 * constants.c.to(u.km / u.s)
             )
-        velocity_cube = make_map_cube(template, velocity_value.value, velocity_value.unit, mask_invalid=True)
-        velocity_width_cube = make_map_cube(
-            template, velocity_width_value.value, velocity_width_value.unit, mask_invalid=True
+        cubes.extend(
+            [
+                ("velocity", make_map_cube(template, velocity_value.value, velocity_value.unit, mask_invalid=True)),
+                (
+                    "velocity_width",
+                    make_map_cube(template, velocity_width_value.value, velocity_width_value.unit, mask_invalid=True),
+                ),
+            ]
         )
-        cubes.extend([("velocity", velocity_cube), ("velocity_width", velocity_width_cube)])
     return RasterCollection(cubes, aligned_axes=tuple(range(len(template.shape))))

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -4,6 +4,7 @@ Red-blue asymmetry utilities for IRIS spectrogram cubes.
 
 import warnings
 from enum import IntEnum
+from dataclasses import dataclass
 
 import numpy as np
 from scipy.interpolate import make_interp_spline
@@ -19,8 +20,6 @@ from irispy.spectrograph import RasterCollection, SpectrogramCube
 from irispy.utils._spectral import drop_extra_coords_dependent_on_axis, make_map_cube, make_spatial_template
 
 __all__ = ["RBAQualityFlag", "calculate_red_blue_asymmetry"]
-
-_INTERPOLATION_DEGREES = {"linear": 1, "quadratic": 2, "cubic": 3}
 
 
 class RBAQualityFlag(IntEnum):
@@ -80,16 +79,7 @@ def _make_velocity_wcs(base_wcs, array_shape, velocity_axis, velocity_grid):
     return WCS(header)
 
 
-def _make_profile_cube(
-    cube,
-    *,
-    data,
-    velocity_grid,
-    wavelength_axis,
-    meta,
-    uncertainty=None,
-    mask=None,
-):
+def _make_profile_cube(cube, *, data, velocity_grid, wavelength_axis, meta, uncertainty=None, mask=None):
     return SpectrogramCube(
         data,
         wcs=_make_velocity_wcs(cube.wcs, data.shape, wavelength_axis, velocity_grid),
@@ -101,10 +91,240 @@ def _make_profile_cube(
     )
 
 
+@dataclass
+class _PixelCoreResult:
+    quality: RBAQualityFlag
+    rba: float = np.nan
+    red_wing: float = np.nan
+    blue_wing: float = np.nan
+    peak_intensity: float = np.nan
+    peak_velocity: float = np.nan
+    red_blue_error: float = np.nan
+    red_wing_error: float = np.nan
+    blue_wing_error: float = np.nan
+
+
+@dataclass
+class _PixelProfileDetail:
+    interp_profile: np.ndarray
+    interp_error: np.ndarray | None = None
+
+
+@dataclass
+class _RBAContext:
+    velocity: np.ndarray
+    interp_velocity: np.ndarray
+    center_on_peak: bool
+    fit_window: float
+    d_velocity: float
+    degree: int
+    red_mask: np.ndarray
+    blue_mask: np.ndarray
+    min_wing_coverage: float
+
+
+def _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows, uncertainty):
+    """
+    Extract data/errors, mask negatives, subtract continuum, move spectral axis to -1.
+    """
+    data = np.asarray(cube.data, dtype=float)
+    if cube.mask is not None:
+        data = np.where(cube.mask, np.nan, data)
+    data = np.where(data < 0, np.nan, data)
+
+    if uncertainty is not None:
+        errors = u.Quantity(uncertainty, cube.unit).to_value(cube.unit)
+    elif cube.uncertainty is not None:
+        errors = np.asarray(cube.uncertainty.array, dtype=float)
+    else:
+        errors = None
+    if errors is not None and cube.mask is not None:
+        errors = np.where(cube.mask, np.nan, errors)
+
+    data = np.moveaxis(data, wavelength_axis, -1)
+    if errors is not None:
+        errors = np.moveaxis(errors, wavelength_axis, -1)
+
+    if continuum_windows is not None:
+        windows = u.Quantity(continuum_windows).to(wavelengths.unit)
+        if windows.shape == (2,):
+            windows = windows[np.newaxis, :]
+        if windows.ndim != 2 or windows.shape[1] != 2:
+            msg = "continuum_windows must have shape (2,) or (n, 2)"
+            raise ValueError(msg)
+        continuum_mask = np.zeros(wavelengths.shape, dtype=bool)
+        for low, high in windows:
+            continuum_mask |= (wavelengths >= low) & (wavelengths <= high)
+        if not continuum_mask.any():
+            msg = "No wavelength points found within continuum_windows"
+            raise ValueError(msg)
+        continuum_values = np.nanmean(data[..., continuum_mask], axis=-1)
+        data = data - continuum_values[..., np.newaxis]
+        if errors is not None:
+            n_finite = np.isfinite(errors[..., continuum_mask]).sum(axis=-1)
+            continuum_errors = np.sqrt(np.nansum(errors[..., continuum_mask] ** 2, axis=-1))
+            continuum_errors = np.where(n_finite > 0, continuum_errors / n_finite, np.nan)
+            errors = np.sqrt(errors**2 + continuum_errors[..., np.newaxis] ** 2)
+
+    return data, errors
+
+
+def _window_profile(profile, profile_error, velocity, peak_index, *, center_on_peak, fit_window, d_velocity):
+    if center_on_peak:
+        if peak_index == 0 or peak_index == profile.size - 1:
+            return None, None, None, RBAQualityFlag.PEAK_AT_EDGE
+        window_pixels = profile.size if d_velocity == 0 else int(fit_window / abs(d_velocity))
+        low_idx = max(0, peak_index - window_pixels)
+        high_idx = min(profile.size, peak_index + window_pixels)
+        fit_slice = slice(low_idx, high_idx)
+        shifted_velocity = velocity[fit_slice] - velocity[peak_index]
+        profile = profile[fit_slice]
+        if profile_error is not None:
+            profile_error = profile_error[fit_slice]
+    else:
+        fit_mask = np.abs(velocity) <= fit_window
+        shifted_velocity = velocity[fit_mask]
+        profile = profile[fit_mask]
+        if profile_error is not None:
+            profile_error = profile_error[fit_mask]
+
+    return shifted_velocity, profile, profile_error, RBAQualityFlag.OK
+
+
+def _interpolate_profile_and_error(shifted_velocity, profile, profile_error, interp_velocity, degree):
+    finite = np.isfinite(shifted_velocity) & np.isfinite(profile)
+    min_points = degree + 1
+    if finite.sum() < min_points:
+        return None, None, RBAQualityFlag.TOO_FEW_POINTS
+
+    sv, sp = shifted_velocity[finite], profile[finite]
+    order = np.argsort(sv)
+    ordered_velocity, ordered_profile = sv[order], sp[order]
+
+    try:
+        interp_profile = make_interp_spline(ordered_velocity, ordered_profile, k=degree)(
+            interp_velocity, extrapolate=False
+        )
+    except ValueError:
+        return None, None, RBAQualityFlag.INTERP_FAILED
+
+    interp_error = None
+    if profile_error is not None:
+        ordered_error = profile_error[finite][order]
+        finite_error = np.isfinite(ordered_error)
+        if finite_error.sum() >= min_points:
+            try:
+                interp_error = make_interp_spline(
+                    ordered_velocity[finite_error], ordered_error[finite_error], k=degree
+                )(interp_velocity, extrapolate=False)
+                interp_error = np.where(interp_error >= 0, interp_error, np.nan)
+            except ValueError:
+                return None, None, RBAQualityFlag.INTERP_FAILED
+
+    return interp_profile, interp_error, RBAQualityFlag.OK
+
+
+def _compute_wings_and_peak(interp_profile, red_mask, blue_mask, min_wing_coverage):
+    red_finite = red_mask & np.isfinite(interp_profile)
+    blue_finite = blue_mask & np.isfinite(interp_profile)
+    if red_finite.sum() < min_wing_coverage * red_mask.sum() or blue_finite.sum() < min_wing_coverage * blue_mask.sum():
+        return np.nan, np.nan, np.nan, RBAQualityFlag.INCOMPLETE_WINGS
+
+    red_intensity = np.nanmean(interp_profile[red_finite]) if red_finite.any() else np.nan
+    blue_intensity = np.nanmean(interp_profile[blue_finite]) if blue_finite.any() else np.nan
+    peak = np.nanmax(interp_profile)
+    if not np.isfinite(peak) or np.isclose(peak, 0):
+        return np.nan, np.nan, np.nan, RBAQualityFlag.PEAK_IS_ZERO
+
+    return red_intensity, blue_intensity, peak, RBAQualityFlag.OK
+
+
+def _propagate_rba_error(red_intensity, blue_intensity, peak, interp_error, red_mask, blue_mask, interp_profile):
+    """Propagate uncertainties through ``(I_R - I_B) / I_p``."""
+    if interp_error is None:
+        return np.nan, np.nan, np.nan
+
+    n_red = np.isfinite(interp_error[red_mask]).sum()
+    n_blue = np.isfinite(interp_error[blue_mask]).sum()
+    red_err = np.sqrt(np.nansum(interp_error[red_mask] ** 2)) / n_red if n_red > 0 else np.nan
+    blue_err = np.sqrt(np.nansum(interp_error[blue_mask] ** 2)) / n_blue if n_blue > 0 else np.nan
+    peak_err = interp_error[np.nanargmax(interp_profile)]
+    numerator = red_intensity - blue_intensity
+    num_err = np.sqrt(red_err**2 + blue_err**2)
+
+    rba_error = np.nan
+    numerator_is_zero = np.isclose(numerator, 0)
+    if np.isfinite(num_err) and (numerator_is_zero or np.isfinite(peak_err)):
+        variance = (num_err / peak) ** 2
+        if not numerator_is_zero:
+            variance += (numerator * peak_err / peak**2) ** 2
+        rba_error = np.sqrt(variance)
+
+    return rba_error, red_err, blue_err
+
+
+def _process_pixel(profile, profile_error, ctx: _RBAContext):
+    """
+    Compute RBA for a single spatial pixel.
+
+    Returns (``_PixelCoreResult``, ``_PixelProfileDetail | None``).
+    """
+    finite_profile = np.isfinite(profile)
+    if not finite_profile.any():
+        return _PixelCoreResult(quality=RBAQualityFlag.NO_FINITE_DATA), None
+
+    peak_index = np.nanargmax(np.where(finite_profile, profile, np.nan))
+    peak_velocity = ctx.velocity[peak_index]
+
+    shifted_velocity, profile, profile_error, quality = _window_profile(
+        profile,
+        profile_error,
+        ctx.velocity,
+        peak_index,
+        center_on_peak=ctx.center_on_peak,
+        fit_window=ctx.fit_window,
+        d_velocity=ctx.d_velocity,
+    )
+    if quality is not RBAQualityFlag.OK:
+        return _PixelCoreResult(quality=quality, peak_velocity=peak_velocity), None
+
+    interp_profile, interp_error, interp_quality = _interpolate_profile_and_error(
+        shifted_velocity, profile, profile_error, ctx.interp_velocity, ctx.degree
+    )
+    detail = _PixelProfileDetail(interp_profile, interp_error) if interp_profile is not None else None
+
+    if interp_quality is not RBAQualityFlag.OK:
+        return _PixelCoreResult(quality=interp_quality, peak_velocity=peak_velocity), detail
+
+    red_intensity, blue_intensity, peak, quality = _compute_wings_and_peak(
+        interp_profile, ctx.red_mask, ctx.blue_mask, ctx.min_wing_coverage
+    )
+    if quality is not RBAQualityFlag.OK:
+        return _PixelCoreResult(quality=quality, peak_velocity=peak_velocity), detail
+
+    rba = (red_intensity - blue_intensity) / peak
+    rba_error, red_err, blue_err = _propagate_rba_error(
+        red_intensity, blue_intensity, peak, interp_error, ctx.red_mask, ctx.blue_mask, interp_profile
+    )
+
+    core = _PixelCoreResult(
+        quality=RBAQualityFlag.OK,
+        rba=rba,
+        red_wing=red_intensity,
+        blue_wing=blue_intensity,
+        peak_intensity=peak,
+        peak_velocity=peak_velocity,
+        red_blue_error=rba_error,
+        red_wing_error=red_err,
+        blue_wing_error=blue_err,
+    )
+    return core, detail
+
+
 def calculate_red_blue_asymmetry(
     cube,
     *,
-    rest_wavelength,
+    rest_wavelength=None,
     velocity_range=(50, 150) * u.km / u.s,
     velocity_window=None,
     fit_window=None,
@@ -112,8 +332,7 @@ def calculate_red_blue_asymmetry(
     center_on_peak=True,
     continuum_windows=None,
     uncertainty=None,
-    interpolation_kind="cubic",
-    mask_negative=True,
+    degree=3,
     min_intensity=None,
     saturation_limit=None,
     return_profiles=True,
@@ -130,8 +349,10 @@ def calculate_red_blue_asymmetry(
     ----------
     cube : `irispy.spectrograph.SpectrogramCube`
         Input spectrogram cube.
-    rest_wavelength : `astropy.units.Quantity`
+    rest_wavelength : `astropy.units.Quantity`, optional
         Rest wavelength used to convert the spectral axis to Doppler velocity.
+        If omitted, read from ``cube.meta.rest_wavelength`` (requires an
+        `~irispy.meta.SGMeta` instance with a ``TWAVE<n>`` FITS keyword).
     velocity_range : `astropy.units.Quantity`, optional
         Two positive velocities defining the wing range to average.
     velocity_window : `astropy.units.Quantity`, optional
@@ -152,35 +373,34 @@ def calculate_red_blue_asymmetry(
     uncertainty : `astropy.units.Quantity`, optional
         Per-bin intensity uncertainty. If omitted, ``cube.uncertainty`` is
         used when available.
-    interpolation_kind : {"linear", "quadratic", "cubic"} or `int`, optional
-        Spline degree used by `scipy.interpolate.make_interp_spline`.
-    mask_negative : `bool`, optional
-        If `True`, negative intensities are set to NaN before computing
-        moments.
+    degree : `int`, optional
+        Spline degree for `scipy.interpolate.make_interp_spline`.
     min_intensity : `float` or `astropy.units.Quantity`, optional
         Minimum peak intensity required for a pixel to be processed.
-        Pixels with a peak below this threshold are skipped and assigned
-        quality flag `~irispy.utils.red_blue.RBAQualityFlag.LOW_SIGNAL`.
+        Pixels below this threshold are assigned quality flag
+        `~irispy.utils.red_blue.RBAQualityFlag.LOW_SIGNAL`.
     saturation_limit : `float` or `astropy.units.Quantity`, optional
-        Maximum allowed peak intensity. Pixels where the peak exceeds this
-        value are treated as saturated, skipped, and assigned quality flag
-        `~irispy.utils.red_blue.RBAQualityFlag.SATURATED`.
+        Maximum allowed peak intensity. Pixels above this value are assigned
+        quality flag `~irispy.utils.red_blue.RBAQualityFlag.SATURATED`.
     return_profiles : `bool`, optional
-        If `True`, include plot-ready 3D ``"observed_profile"`` and
-        ``"interpolated_profile"`` cubes in the output. Set to `False` to
-        reduce peak memory use when only the 2D maps are needed.
+        If `True`, include 3D ``"observed_profile"`` and
+        ``"interpolated_profile"`` cubes in the output.
 
     Returns
     -------
     `irispy.spectrograph.RasterCollection`
-        Collection with 2D maps. When ``return_profiles=True``, the collection
-        also includes plot-ready 3D ``"observed_profile"`` and
-        ``"interpolated_profile"`` `~irispy.spectrograph.SpectrogramCube`
-        instances. The ``"quality"`` cube stores per-pixel integer flags
-        described by
-        `irispy.utils.red_blue.RBAQualityFlag`.
     """
-    # -- Validate velocity_range ------------------------------------------------
+    if rest_wavelength is None:
+        try:
+            rest_wavelength = cube.meta.rest_wavelength
+        except (AttributeError, TypeError) as exc:
+            msg = (
+                "rest_wavelength was not provided and could not be read from cube.meta. "
+                "Pass rest_wavelength explicitly or provide a cube with SGMeta containing TWAVE keywords."
+            )
+            raise ValueError(msg) from exc
+    rest_wavelength = u.Quantity(rest_wavelength).to(u.nm)
+
     velocity_range = u.Quantity(velocity_range).to(u.km / u.s)
     if velocity_range.shape != (2,):
         msg = "velocity_range must contain two velocities"
@@ -190,13 +410,15 @@ def calculate_red_blue_asymmetry(
         msg = "velocity_range must be positive and increasing"
         raise ValueError(msg)
 
-    velocity_window = velocity_high + 50 * u.km / u.s if velocity_window is None else u.Quantity(velocity_window)
-    velocity_window = velocity_window.to_value(u.km / u.s)
-    fit_window = velocity_high + 100 * u.km / u.s if fit_window is None else u.Quantity(fit_window)
-    fit_window = fit_window.to_value(u.km / u.s)
+    velocity_window = (
+        velocity_high + 50 * u.km / u.s if velocity_window is None else u.Quantity(velocity_window)
+    ).to_value(u.km / u.s)
+    fit_window = (velocity_high + 100 * u.km / u.s if fit_window is None else u.Quantity(fit_window)).to_value(
+        u.km / u.s
+    )
     dv = u.Quantity(dv).to_value(u.km / u.s)
     if velocity_window <= velocity_high.to_value(u.km / u.s):
-        msg = "velocity_window must be larger than the high end of velocity_range"
+        msg = "velocity_window must be larger than velocity_range high end"
         raise ValueError(msg)
     if fit_window <= velocity_window:
         msg = "fit_window must be larger than velocity_window"
@@ -204,79 +426,43 @@ def calculate_red_blue_asymmetry(
     if dv <= 0:
         msg = "dv must be positive"
         raise ValueError(msg)
-    interpolation_degree = _INTERPOLATION_DEGREES.get(interpolation_kind, interpolation_kind)
-    try:
-        interpolation_degree = int(interpolation_degree)
-    except (TypeError, ValueError) as exc:
-        msg = "interpolation_kind must be 'linear', 'quadratic', 'cubic', or an integer spline degree"
-        raise ValueError(msg) from exc
-    if interpolation_degree < 0:
-        msg = "interpolation_kind must be a non-negative spline degree"
+    degree = int(degree)
+    if degree < 0:
+        msg = "degree must be a non-negative integer"
         raise ValueError(msg)
 
-    # -- Locate spectral axis and compute velocities ----------------------------
     try:
-        wavelength_axis = next(
-            axis
-            for axis, physical_types in enumerate(cube.array_axis_physical_types)
-            if physical_types and "em.wl" in physical_types
-        )
-    except StopIteration as exc:
+        wavelength_axis = cube.wavelength_axis
+    except (AttributeError, StopIteration) as exc:
         msg = "Could not identify a spectral wavelength axis on the input cube"
         raise ValueError(msg) from exc
     wavelengths = cube.axis_world_coords(wavelength_axis)[0].to(u.nm)
-    rest_wavelength = u.Quantity(rest_wavelength).to(wavelengths.unit)
+    rest_wavelength = rest_wavelength.to(wavelengths.unit)
     velocity = ((wavelengths - rest_wavelength) / rest_wavelength * constants.c).to_value(u.km / u.s)
     interp_velocity = np.arange(-velocity_window, velocity_window + dv, dv)
-    velocity_range_value = (velocity_low.to_value(u.km / u.s), velocity_high.to_value(u.km / u.s))
+    velocity_range_kms = (velocity_low.to_value(u.km / u.s), velocity_high.to_value(u.km / u.s))
 
-    # -- Prepare data and uncertainty -------------------------------------------
-    data = np.asarray(cube.data, dtype=float)
-    if cube.mask is not None:
-        data = np.where(cube.mask, np.nan, data)
-    if mask_negative:
-        data = np.where(data < 0, np.nan, data)
+    data, errors = _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows, uncertainty)
 
-    if uncertainty is not None:
-        errors = u.Quantity(uncertainty, cube.unit).to_value(cube.unit)
-    elif cube.uncertainty is not None:
-        errors = np.asarray(cube.uncertainty.array, dtype=float)
-    else:
-        errors = None
-    if errors is not None and cube.mask is not None:
-        errors = np.where(cube.mask, np.nan, errors)
-
-    # -- Continuum subtraction --------------------------------------------------
-    if continuum_windows is not None:
-        windows = u.Quantity(continuum_windows).to(wavelengths.unit)
-        if windows.shape == (2,):
-            windows = windows[np.newaxis, :]
-        if windows.ndim != 2 or windows.shape[1] != 2:
-            msg = "continuum_windows must have shape (2,) or (n, 2)"
-            raise ValueError(msg)
-        continuum = np.zeros(wavelengths.shape, dtype=bool)
-        for low, high in windows:
-            continuum |= (wavelengths >= low) & (wavelengths <= high)
-        if not continuum.any():
-            msg = "No wavelength points found within continuum_windows"
-            raise ValueError(msg)
-        data = np.moveaxis(data, wavelength_axis, -1)
-        if errors is not None:
-            errors = np.moveaxis(errors, wavelength_axis, -1)
-        continuum_values = np.nanmean(data[..., continuum], axis=-1)
-        data = data - continuum_values[..., np.newaxis]
-        if errors is not None:
-            n_finite = np.isfinite(errors[..., continuum]).sum(axis=-1)
-            continuum_errors = np.sqrt(np.nansum(errors[..., continuum] ** 2, axis=-1))
-            continuum_errors = np.where(n_finite > 0, continuum_errors / n_finite, np.nan)
-            errors = np.sqrt(errors**2 + continuum_errors[..., np.newaxis] ** 2)
-    else:
-        data = np.moveaxis(data, wavelength_axis, -1)
-        if errors is not None:
-            errors = np.moveaxis(errors, wavelength_axis, -1)
-
-    # -- Per-pixel red-blue computation -----------------------------------------
     output_shape = data.shape[:-1]
+    d_velocity = float(np.nanmean(np.diff(velocity))) if velocity.size > 1 else 1.0
+
+    low, high = velocity_range_kms
+    red_mask = (interp_velocity >= low) & (interp_velocity <= high)
+    blue_mask = (interp_velocity >= -high) & (interp_velocity <= -low)
+
+    ctx = _RBAContext(
+        velocity=velocity,
+        interp_velocity=interp_velocity,
+        center_on_peak=center_on_peak,
+        fit_window=fit_window,
+        d_velocity=d_velocity,
+        degree=degree,
+        red_mask=red_mask,
+        blue_mask=blue_mask,
+        min_wing_coverage=0.8,
+    )
+
     red_blue = np.full(output_shape, np.nan)
     red_blue_error = np.full(output_shape, np.nan)
     red_wing = np.full(output_shape, np.nan)
@@ -287,24 +473,19 @@ def calculate_red_blue_asymmetry(
     peak_velocity = np.full(output_shape, np.nan)
     quality = np.full(output_shape, RBAQualityFlag.OK, dtype=np.uint8)
 
-    # Apply min_intensity and saturation_limit masks before the loop
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)
         raw_peak = np.nanmax(data, axis=-1)
     if min_intensity is not None:
-        if isinstance(min_intensity, u.Quantity):
-            min_intensity_value = min_intensity.to_value(cube.unit)
-        else:
-            min_intensity_value = min_intensity
-        low_signal = raw_peak < min_intensity_value
-        quality = np.where(low_signal, RBAQualityFlag.LOW_SIGNAL, quality)
+        min_intensity_value = (
+            min_intensity.to_value(cube.unit) if isinstance(min_intensity, u.Quantity) else min_intensity
+        )
+        quality = np.where(raw_peak < min_intensity_value, RBAQualityFlag.LOW_SIGNAL, quality)
     if saturation_limit is not None:
-        if isinstance(saturation_limit, u.Quantity):
-            saturation_limit_value = saturation_limit.to_value(cube.unit)
-        else:
-            saturation_limit_value = saturation_limit
-        saturated = raw_peak > saturation_limit_value
-        quality = np.where(saturated, RBAQualityFlag.SATURATED, quality)
+        saturation_limit_value = (
+            saturation_limit.to_value(cube.unit) if isinstance(saturation_limit, u.Quantity) else saturation_limit
+        )
+        quality = np.where(raw_peak > saturation_limit_value, RBAQualityFlag.SATURATED, quality)
 
     interpolated_profiles = (
         np.full((*output_shape, interp_velocity.size), np.nan, dtype=float) if return_profiles else None
@@ -315,176 +496,83 @@ def calculate_red_blue_asymmetry(
         else None
     )
 
-    low, high = velocity_range_value
-    red_mask = (interp_velocity >= low) & (interp_velocity <= high)
-    blue_mask = (interp_velocity >= -high) & (interp_velocity <= -low)
-
     for index in np.ndindex(output_shape):
         if quality[index] in (RBAQualityFlag.LOW_SIGNAL, RBAQualityFlag.SATURATED):
             continue
-        profile = data[index]
-        profile_error = None if errors is None else errors[index]
-        finite_profile = np.isfinite(profile)
-        if not finite_profile.any():
-            quality[index] = RBAQualityFlag.NO_FINITE_DATA
-            continue
-        peak_index = np.nanargmax(np.where(finite_profile, profile, np.nan))
-        peak_velocity[index] = velocity[peak_index]
 
-        if center_on_peak:
-            # Reject only if the peak itself sits at the very edge of the array
-            if peak_index == 0 or peak_index == profile.size - 1:
-                quality[index] = RBAQualityFlag.PEAK_AT_EDGE
-                continue
-            d_velocity = np.nanmean(np.diff(velocity))
-            window_pixels = int(fit_window / abs(d_velocity))
-            # Clamp the slice to available data (old prototype behaviour)
-            low_idx = max(0, peak_index - window_pixels)
-            high_idx = min(profile.size, peak_index + window_pixels)
-            sl = slice(low_idx, high_idx)
-            shifted_velocity = velocity[sl] - velocity[peak_index]
-            profile = profile[sl]
-            if profile_error is not None:
-                profile_error = profile_error[sl]
-        else:
-            fit_mask = np.abs(velocity) <= fit_window
-            shifted_velocity = velocity[fit_mask]
-            profile = profile[fit_mask]
-            if profile_error is not None:
-                profile_error = profile_error[fit_mask]
+        core, detail = _process_pixel(data[index], None if errors is None else errors[index], ctx)
 
-        # Interpolate onto uniform velocity grid
-        finite = np.isfinite(shifted_velocity) & np.isfinite(profile)
-        min_points = interpolation_degree + 1
-        if finite.sum() < min_points:
-            quality[index] = RBAQualityFlag.TOO_FEW_POINTS
-            continue
-        sv = shifted_velocity[finite]
-        sp = profile[finite]
-        order = np.argsort(sv)
-        ordered_velocity = sv[order]
-        ordered_profile = sp[order]
-        try:
-            interp_profile = make_interp_spline(ordered_velocity, ordered_profile, k=interpolation_degree)(
-                interp_velocity,
-                extrapolate=False,
-            )
-        except ValueError:
-            quality[index] = RBAQualityFlag.INTERP_FAILED
-            continue
-        if profile_error is not None:
-            ordered_error = profile_error[finite][order]
-            finite_error = np.isfinite(ordered_error)
-            if finite_error.sum() >= min_points:
-                try:
-                    interp_error = make_interp_spline(
-                        ordered_velocity[finite_error],
-                        ordered_error[finite_error],
-                        k=interpolation_degree,
-                    )(interp_velocity, extrapolate=False)
-                    interp_error = np.where(interp_error >= 0, interp_error, np.nan)
-                except ValueError:
-                    quality[index] = RBAQualityFlag.INTERP_FAILED
-                    continue
-            else:
-                interp_error = None
-        else:
-            interp_error = None
+        red_blue[index] = core.rba
+        red_wing[index] = core.red_wing
+        blue_wing[index] = core.blue_wing
+        peak_intensity[index] = core.peak_intensity
+        peak_velocity[index] = core.peak_velocity
+        quality[index] = core.quality
+        red_blue_error[index] = core.red_blue_error
+        red_wing_error[index] = core.red_wing_error
+        blue_wing_error[index] = core.blue_wing_error
+        if return_profiles and detail is not None:
+            interpolated_profiles[index] = detail.interp_profile
+            if interpolated_errors is not None and detail.interp_error is not None:
+                interpolated_errors[index] = detail.interp_error
 
-        if return_profiles:
-            interpolated_profiles[index] = interp_profile
-        if interp_error is not None and return_profiles:
-            interpolated_errors[index] = interp_error
-
-        red_finite = red_mask & np.isfinite(interp_profile)
-        blue_finite = blue_mask & np.isfinite(interp_profile)
-        if red_finite.sum() < 0.8 * red_mask.sum() or blue_finite.sum() < 0.8 * blue_mask.sum():
-            quality[index] = RBAQualityFlag.INCOMPLETE_WINGS
-            continue
-        red_intensity = np.nanmean(interp_profile[red_finite]) if red_finite.any() else np.nan
-        blue_intensity = np.nanmean(interp_profile[blue_finite]) if blue_finite.any() else np.nan
-        peak = np.nanmax(interp_profile)
-        if not np.isfinite(peak) or peak == 0:
-            quality[index] = RBAQualityFlag.PEAK_IS_ZERO
-            continue
-        rba = (red_intensity - blue_intensity) / peak
-        red_blue[index] = rba
-        red_wing[index] = red_intensity
-        blue_wing[index] = blue_intensity
-        peak_intensity[index] = peak
-
-        if interp_error is not None and np.isfinite(rba):
-            n_red = np.isfinite(interp_error[red_mask]).sum()
-            n_blue = np.isfinite(interp_error[blue_mask]).sum()
-            red_err = np.sqrt(np.nansum(interp_error[red_mask] ** 2)) / n_red if n_red > 0 else np.nan
-            blue_err = np.sqrt(np.nansum(interp_error[blue_mask] ** 2)) / n_blue if n_blue > 0 else np.nan
-            peak_err = interp_error[np.nanargmax(interp_profile)]
-            numerator = red_intensity - blue_intensity
-            num_err = np.sqrt(red_err**2 + blue_err**2)
-            if np.isfinite(num_err) and (numerator == 0 or np.isfinite(peak_err)):
-                variance = (num_err / peak) ** 2
-                if numerator != 0:
-                    variance += (numerator * peak_err / peak**2) ** 2
-                red_blue_error[index] = np.sqrt(variance)
-            red_wing_error[index] = red_err
-            blue_wing_error[index] = blue_err
-
-    # -- Build meta with computation parameters ---------------------------------
     meta = {
         "rba_rest_wavelength": rest_wavelength.to_value(u.nm),
         "rba_rest_wavelength_unit": "nm",
-        "rba_velocity_range": velocity_range_value,
+        "rba_velocity_range": velocity_range_kms,
         "rba_velocity_window": velocity_window,
         "rba_fit_window": fit_window,
         "rba_dv": dv,
         "rba_center_on_peak": center_on_peak,
-        "rba_interpolation_kind": interpolation_kind,
-        "rba_mask_negative": mask_negative,
+        "rba_interpolation_degree": degree,
     }
     if continuum_windows is not None:
         meta["rba_continuum_windows"] = str(continuum_windows)
+
+    template = make_spatial_template(cube, wavelength_axis)
 
     def _make_cube(values, unit, *, mask=None):
         c = make_map_cube(template, values, unit, mask=mask)
         c.meta.update(meta)
         return c
 
-    # -- Build output RasterCollection ------------------------------------------
-    template = make_spatial_template(cube, wavelength_axis)
     cubes = [
-        ("red_blue_asymmetry", _make_cube(red_blue, u.dimensionless_unscaled, mask=~np.isfinite(red_blue))),
-        ("red_wing", _make_cube(red_wing, cube.unit, mask=~np.isfinite(red_wing))),
-        ("blue_wing", _make_cube(blue_wing, cube.unit, mask=~np.isfinite(blue_wing))),
-        ("peak_intensity", _make_cube(peak_intensity, cube.unit, mask=~np.isfinite(peak_intensity))),
-        ("peak_velocity", _make_cube(peak_velocity, u.km / u.s, mask=~np.isfinite(peak_velocity))),
-        ("quality", _make_cube(quality, u.dimensionless_unscaled)),
+        ("red_blue_asymmetry", red_blue, u.dimensionless_unscaled),
+        ("red_wing", red_wing, cube.unit),
+        ("blue_wing", blue_wing, cube.unit),
+        ("peak_intensity", peak_intensity, cube.unit),
+        ("peak_velocity", peak_velocity, u.km / u.s),
+        ("quality", quality, u.dimensionless_unscaled),
     ]
     if errors is not None:
         cubes.extend(
             [
-                (
-                    "red_blue_asymmetry_error",
-                    _make_cube(red_blue_error, u.dimensionless_unscaled, mask=~np.isfinite(red_blue_error)),
-                ),
-                ("red_wing_error", _make_cube(red_wing_error, cube.unit, mask=~np.isfinite(red_wing_error))),
-                ("blue_wing_error", _make_cube(blue_wing_error, cube.unit, mask=~np.isfinite(blue_wing_error))),
-            ],
+                ("red_blue_asymmetry_error", red_blue_error, u.dimensionless_unscaled),
+                ("red_wing_error", red_wing_error, cube.unit),
+                ("blue_wing_error", blue_wing_error, cube.unit),
+            ]
         )
+
+    result_cubes = []
+    for name, values, unit in cubes:
+        mask = None if name == "quality" else ~np.isfinite(values)
+        result_cubes.append((name, _make_cube(values, unit, mask=mask)))
 
     if return_profiles:
         observed_data = np.moveaxis(data, -1, wavelength_axis)
-        observed_mask = ~np.isfinite(observed_data)
-        observed_uncertainty = None
-        if errors is not None:
-            observed_uncertainty = StdDevUncertainty(np.moveaxis(errors, -1, wavelength_axis))
-
         interpolated_data = np.moveaxis(interpolated_profiles, -1, wavelength_axis)
+        observed_mask = ~np.isfinite(observed_data)
         interpolated_mask = ~np.isfinite(interpolated_data)
-        interpolated_uncertainty = None
-        if interpolated_errors is not None:
-            interpolated_uncertainty = StdDevUncertainty(np.moveaxis(interpolated_errors, -1, wavelength_axis))
+        observed_uncertainty = (
+            StdDevUncertainty(np.moveaxis(errors, -1, wavelength_axis)) if errors is not None else None
+        )
+        interpolated_uncertainty = (
+            StdDevUncertainty(np.moveaxis(interpolated_errors, -1, wavelength_axis))
+            if interpolated_errors is not None
+            else None
+        )
 
-        cubes.extend(
+        result_cubes.extend(
             [
                 (
                     "observed_profile",
@@ -512,4 +600,5 @@ def calculate_red_blue_asymmetry(
                 ),
             ]
         )
-    return RasterCollection(cubes)
+
+    return RasterCollection(result_cubes)

--- a/irispy/utils/spectrograph.py
+++ b/irispy/utils/spectrograph.py
@@ -7,10 +7,8 @@ import numpy as np
 import astropy.units as u
 from astropy import constants
 
-from ndcube.wcs.tools import unwrap_wcs_to_fitswcs
-
 from irispy.spectrograph import SpectrogramCube, SpectrogramCubeSequence
-from irispy.utils.constants import RADIANCE_UNIT, SLIT_WIDTH
+from irispy.utils.constants import RADIANCE_UNIT
 from irispy.utils.response import get_interpolated_effective_area, get_latest_response
 
 __all__ = [
@@ -31,15 +29,10 @@ def radiometric_calibration(
 
     The data is also exposure time corrected during the conversion.
 
-    This takes into account the spectral dispersion and solid angle of the pixels based on the WCS.
-    Which is different from the IDL code as does not take spectral dispersion into account.
-    If you want the same results as the IDL code, can multiply the output by the spectral dispersion.
-
-    The spectral dispersion and solid angle are calculated using the WCS information.
-    The wavelength axis and spatial axis should be determined dynamically from the WCS, rather than assuming fixed axis indices.
-    For example, the spectral dispersion is calculated as ``cube.wcs.wcs.cdelt[wavelength_axis] * cube.wcs.wcs.cunit[wavelength_axis]``,
-    and the solid angle as ``cube.wcs.wcs.cdelt[spatial_axis] * cube.wcs.wcs.cunit[spatial_axis] * SLIT_WIDTH``,
-    where ``wavelength_axis`` and ``spatial_axis`` are determined from the WCS.
+    This takes into account the spectral dispersion and solid angle of the pixels
+    based on the WCS, which is different from the IDL code that does not take spectral
+    dispersion into account. If you want the same results as the IDL code, can multiply
+    the output by the spectral dispersion.
 
     Parameters
     ----------
@@ -63,15 +56,9 @@ def radiometric_calibration(
     """
     if isinstance(cube, SpectrogramCubeSequence):
         return SpectrogramCubeSequence([radiometric_calibration(c) for c in cube])
-    detector_type = cube.meta.detector
-    underlying_wcs = unwrap_wcs_to_fitswcs(cube.wcs)[0].wcs if not hasattr(cube.wcs, "wcs") else cube.wcs.wcs
-    # Get spectral dispersion per pixel.
-    spectral_wcs_index = np.where(np.array(underlying_wcs.ctype) == "WAVE")[0][0]
-    spectral_dispersion_per_pixel = underlying_wcs.cdelt[spectral_wcs_index] * underlying_wcs.cunit[spectral_wcs_index]
-    # Get solid angle from slit width for a pixel.
-    lat_wcs_index = ["HPLT" in c for c in underlying_wcs.ctype]
-    lat_wcs_index = np.arange(len(underlying_wcs.ctype))[lat_wcs_index][0]
-    solid_angle = underlying_wcs.cdelt[lat_wcs_index] * underlying_wcs.cunit[lat_wcs_index] * SLIT_WIDTH
+    detector_type = cube.meta.detector_band
+    spectral_dispersion_per_pixel = cube.spectral_dispersion
+    solid_angle = cube.solid_angle
     # Get wavelength for each pixel.
     wavelength_axis_index = next(
         axis

--- a/irispy/utils/tests/test_moments.py
+++ b/irispy/utils/tests/test_moments.py
@@ -56,12 +56,17 @@ def test_calculate_moments_basic(sns_sg_file):
 def test_calculate_moments_sliced_cube(sns_sg_file):
     """
     Test that calculate_moments works on a sliced cube and with default arguments.
+
+    With real IRIS data, rest_wavelength is auto-detected from cube metadata, so
+    velocity outputs are included.
     """
     raster_collection = read_files(sns_sg_file)
     cube = raster_collection["C II 1336"][0]
     cube_slice = cube[10, :, :]
     moments = calculate_moments(cube_slice)
-    assert set(moments.keys()) == {"intensity", "centroid", "width"}
+    assert "intensity" in moments
+    assert "centroid" in moments
+    assert "width" in moments
     assert moments["intensity"].shape == cube_slice.shape[:-1]
     assert moments["centroid"].shape == cube_slice.shape[:-1]
     assert moments["width"].shape == cube_slice.shape[:-1]
@@ -106,13 +111,13 @@ def test_calculate_moments_asymmetric_wings_rejects_bare_tuple():
 
 def test_calculate_moments_wings_without_rest_wavelength(sns_sg_file):
     """
-    Test that calculate_moments raises an error when wings is given without
-    rest_wavelength.
+    Test that calculate_moments auto-detects rest_wavelength from cube metadata when
+    wings is given without explicit rest_wavelength.
     """
     raster_collection = read_files(sns_sg_file)
     cube = raster_collection["C II 1336"][0]
-    with pytest.raises(ValueError, match="rest_wavelength must be provided"):
-        calculate_moments(cube, wings=1.0 * u.Angstrom)
+    moments = calculate_moments(cube, wings=5.0 * u.Angstrom)
+    assert "velocity" in moments
 
 
 def test_calculate_moments_requires_wavelength_axis():
@@ -123,6 +128,15 @@ def test_calculate_moments_requires_wavelength_axis():
 
     with pytest.raises(ValueError, match="Could not identify a spectral wavelength axis"):
         calculate_moments(cube)
+
+
+def test_calculate_moments_wings_no_meta_no_rest_wavelength():
+    """
+    Wings with no rest_wavelength and no detectable meta should raise.
+    """
+    cube = make_test_spectrogram_cube(np.ones((1, 1, 5)), np.arange(5) * u.nm)
+    with pytest.raises(ValueError, match="rest_wavelength must be provided"):
+        calculate_moments(cube, wings=1.0 * u.Angstrom)
 
 
 def test_calculate_moments_ignores_negative_nonfinite_and_masked_values():

--- a/irispy/utils/tests/test_red_blue.py
+++ b/irispy/utils/tests/test_red_blue.py
@@ -3,11 +3,13 @@ import pytest
 
 import astropy.units as u
 from astropy import constants
+from astropy.io import fits
 from astropy.nddata import StdDevUncertainty
 from astropy.tests.helper import assert_quantity_allclose
 
 import irispy.utils.red_blue as red_blue_module
 from irispy.io.utils import read_files
+from irispy.meta import SGMeta
 from irispy.spectrograph import RasterCollection, SpectrogramCube
 from irispy.tests.helpers import make_test_spectrogram_cube
 from irispy.utils.red_blue import RBAQualityFlag, calculate_red_blue_asymmetry
@@ -37,12 +39,7 @@ def test_calculate_red_blue_asymmetry_red_and_blue_signs():
     data = np.stack([red_profile, blue_profile]).reshape(1, 2, -1)
     cube = make_test_spectrogram_cube(data, wavelengths)
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
 
     assert isinstance(result, RasterCollection)
     assert set(result.keys()) == {
@@ -76,13 +73,7 @@ def test_calculate_red_blue_asymmetry_uses_masked_bins():
     red = (velocity >= 50 * u.km / u.s) & (velocity <= 150 * u.km / u.s)
     cube.mask[..., red] = True
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
-
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
     assert_quantity_allclose(result["red_blue_asymmetry"].data[0, 0] * u.one, 0 * u.one, atol=1e-12 * u.one)
 
 
@@ -96,13 +87,7 @@ def test_calculate_red_blue_asymmetry_output_does_not_inherit_first_wavelength_m
     cube.mask[0, 0, 0] = True
     cube.mask[0, 1, :] = True
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
-
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
     assert not result["red_blue_asymmetry"].mask[0, 0]
     assert result["quality"].data[0, 0] == 0
@@ -115,7 +100,6 @@ def test_calculate_red_blue_asymmetry_requires_wavelength_axis():
     cube.wcs.wcs.ctype[0] = "TIME"
     cube.wcs.wcs.cunit[0] = "s"
     cube.wcs.wcs.set()
-
     with pytest.raises(ValueError, match="Could not identify a spectral wavelength axis"):
         calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH)
 
@@ -132,53 +116,44 @@ def test_calculate_red_blue_asymmetry_with_uncertainty():
         cube,
         rest_wavelength=REST_WAVELENGTH,
         uncertainty=uncertainty,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
     )
-
     assert "red_blue_asymmetry_error" in result
     assert result["red_blue_asymmetry_error"].unit == u.one
     red_wing = float(result["red_wing"].data[0, 0])
     blue_wing = float(result["blue_wing"].data[0, 0])
     peak = float(result["peak_intensity"].data[0, 0])
     numerator = red_wing - blue_wing
-    wing_error = np.sqrt(np.sum(np.full(11, 0.1) ** 2)) / 11
+    n_wing_bins = int((150 - 50) / 10) + 1
+    wing_error = np.sqrt(np.sum(np.full(n_wing_bins, 0.1) ** 2)) / n_wing_bins
     expected_propagated_error = np.sqrt((np.sqrt(2) * wing_error / peak) ** 2 + (numerator * 0.1 / peak**2) ** 2)
-    assert_quantity_allclose(
-        result["red_blue_asymmetry_error"].data[0, 0] * u.one,
-        expected_propagated_error * u.one,
-    )
+    assert_quantity_allclose(result["red_blue_asymmetry_error"].data[0, 0] * u.one, expected_propagated_error * u.one)
+    assert result["red_wing_error"].unit == u.DN
+    assert result["blue_wing_error"].unit == u.DN
+    assert result["red_blue_asymmetry"].meta["rba_rest_wavelength"] == 140.277
+    assert result["red_blue_asymmetry"].meta["rba_center_on_peak"] is False
 
     symmetric_cube = make_test_spectrogram_cube(_flat_wing_profile(velocity).reshape(1, 1, -1), wavelengths)
     symmetric_result = calculate_red_blue_asymmetry(
         symmetric_cube,
         rest_wavelength=REST_WAVELENGTH,
         uncertainty=uncertainty,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
     )
     expected_zero_error = np.sqrt(2) * wing_error / 10
     assert_quantity_allclose(symmetric_result["red_blue_asymmetry"].data[0, 0] * u.one, 0 * u.one)
     assert_quantity_allclose(
-        symmetric_result["red_blue_asymmetry_error"].data[0, 0] * u.one,
-        expected_zero_error * u.one,
+        symmetric_result["red_blue_asymmetry_error"].data[0, 0] * u.one, expected_zero_error * u.one
     )
-
-    assert result["red_wing_error"].unit == u.DN
-    assert result["blue_wing_error"].unit == u.DN
-    # Meta should record the parameters used
-    assert result["red_blue_asymmetry"].meta["rba_rest_wavelength"] == 140.277
-    assert result["red_blue_asymmetry"].meta["rba_center_on_peak"] is False
 
 
 def test_calculate_red_blue_asymmetry_flags_error_interpolation_failure(monkeypatch):
     original_make_interp_spline = red_blue_module.make_interp_spline
-    calls = 0
 
     def fail_on_error_spline(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        if calls == 2:
+        if np.allclose(np.asarray(args[1]), 0.1):
             msg = "error spline failed"
             raise ValueError(msg)
         return original_make_interp_spline(*args, **kwargs)
@@ -192,28 +167,21 @@ def test_calculate_red_blue_asymmetry_flags_error_interpolation_failure(monkeypa
         cube,
         rest_wavelength=REST_WAVELENGTH,
         uncertainty=np.full(cube.shape, 0.1) * u.DN,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
     )
-
     assert RBAQualityFlag(result["quality"].data[0, 0]) is RBAQualityFlag.INTERP_FAILED
     assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
 
 
 def test_calculate_red_blue_asymmetry_center_on_peak():
-    """
-    Test that center_on_peak=True correctly aligns a Doppler-shifted line.
-    """
     velocity = np.arange(-200, 201, 10) * u.km / u.s
     wavelengths = _wavelengths_from_velocity(velocity)
-    # Create a line peaked at +30 km/s with red excess
     profile = np.ones(velocity.shape, dtype=float)
     peak_wvl = _wavelengths_from_velocity(30 * u.km / u.s)
     sigma_wvl = abs(_wavelengths_from_velocity(10 * u.km / u.s) - peak_wvl).value
     profile += 9 * np.exp(-0.5 * ((wavelengths.value - peak_wvl.value) / sigma_wvl) ** 2)
-    # Add red wing excess
-    red = (velocity >= 50 * u.km / u.s) & (velocity <= 150 * u.km / u.s)
-    profile[red] += 2
+    profile[(velocity >= 50 * u.km / u.s) & (velocity <= 150 * u.km / u.s)] += 2
     data = profile.reshape(1, 1, -1)
     cube = make_test_spectrogram_cube(data, wavelengths)
 
@@ -223,14 +191,10 @@ def test_calculate_red_blue_asymmetry_center_on_peak():
         velocity_range=(50, 150) * u.km / u.s,
         velocity_window=160 * u.km / u.s,
         fit_window=190 * u.km / u.s,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=True,
     )
-
-    # Positive RBA because red wing has excess
     assert result["red_blue_asymmetry"].data[0, 0] > 0
-    # With center_on_peak=True the peak should be found and aligned, so the
-    # blue wing (now centered on the peak) should NOT have the excess.
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
 
 
@@ -242,16 +206,7 @@ def test_calculate_red_blue_asymmetry_return_profiles():
     cube = make_test_spectrogram_cube(data, wavelengths)
     cube.uncertainty = StdDevUncertainty(np.full(cube.shape, 0.1))
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
-
-    assert isinstance(result, RasterCollection)
-    assert "observed_profile" in result
-    assert "interpolated_profile" in result
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
     observed_cube = result["observed_profile"]
     interp_cube = result["interpolated_profile"]
     assert isinstance(observed_cube, SpectrogramCube)
@@ -261,14 +216,8 @@ def test_calculate_red_blue_asymmetry_return_profiles():
     assert "spect.dopplerVeloc" in observed_cube.wcs.world_axis_physical_types
     assert "spect.dopplerVeloc" in interp_cube.wcs.world_axis_physical_types
     assert interp_cube.uncertainty.array.shape == interp_cube.shape
-
-    observed_profile = observed_cube[0, 0]
-    interp_profile = interp_cube[0, 1]
-    assert observed_profile.data.shape == (41,)
-    assert interp_profile.data.shape == (41,)
-    assert_quantity_allclose(observed_profile.axis_world_coords(0)[0], velocity)
-    assert_quantity_allclose(interp_profile.axis_world_coords(0)[0], np.arange(-200, 201, 10) * u.km / u.s)
-    assert np.isfinite(interp_profile.data).all()
+    assert_quantity_allclose(observed_cube[0, 0].axis_world_coords(0)[0], velocity)
+    assert np.isfinite(interp_cube[0, 1].data).all()
 
 
 def test_calculate_red_blue_asymmetry_return_profiles_on_sliced_cube():
@@ -278,13 +227,7 @@ def test_calculate_red_blue_asymmetry_return_profiles_on_sliced_cube():
     data = np.tile(profile, (2, 3, 1))
     cube = make_test_spectrogram_cube(data, wavelengths)[:, :1, :]
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
-
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
     assert result["observed_profile"].shape == cube.shape
     assert result["interpolated_profile"].shape == (2, 1, 41)
     assert_quantity_allclose(
@@ -302,14 +245,40 @@ def test_calculate_red_blue_asymmetry_can_skip_profile_outputs():
     result = calculate_red_blue_asymmetry(
         cube,
         rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
         return_profiles=False,
     )
-
     assert "observed_profile" not in result
     assert "interpolated_profile" not in result
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
+
+
+def test_calculate_red_blue_asymmetry_continuum_subtraction():
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    profile = _flat_wing_profile(velocity, red_excess=2)
+    data = (profile + 5).reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wavelengths)
+
+    result_without = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+
+    continuum_wavelengths = (
+        u.Quantity([[wavelengths[0].value, wavelengths[2].value], [wavelengths[-3].value, wavelengths[-1].value]])
+        * wavelengths.unit
+    )
+    result_with = calculate_red_blue_asymmetry(
+        cube,
+        rest_wavelength=REST_WAVELENGTH,
+        degree=1,
+        center_on_peak=False,
+        continuum_windows=continuum_wavelengths,
+    )
+    rba_without = result_without["red_blue_asymmetry"].data[0, 0]
+    rba_with = result_with["red_blue_asymmetry"].data[0, 0]
+    assert np.isfinite(rba_with)
+    assert_quantity_allclose(rba_with * u.one, (2 / 9) * u.one)
+    assert not np.isclose(rba_without, rba_with)
 
 
 def test_calculate_red_blue_asymmetry_flags_incomplete_wings():
@@ -326,22 +295,21 @@ def test_calculate_red_blue_asymmetry_flags_incomplete_wings():
         velocity_range=(50, 150) * u.km / u.s,
         velocity_window=160 * u.km / u.s,
         fit_window=190 * u.km / u.s,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=True,
     )
-
     assert RBAQualityFlag(result["quality"].data[0, 0]) is RBAQualityFlag.INCOMPLETE_WINGS
     assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
 
 
 @pytest.mark.parametrize(
-    ("option", "value", "expected_reason"),
+    ("option", "value", "expected_flag"),
     [
-        ("min_intensity", 15, "below min_intensity"),
-        ("saturation_limit", 5, "above saturation_limit"),
+        ("min_intensity", 15, RBAQualityFlag.LOW_SIGNAL),
+        ("saturation_limit", 5, RBAQualityFlag.SATURATED),
     ],
 )
-def test_calculate_red_blue_asymmetry_quality_thresholds(option, value, expected_reason):
+def test_calculate_red_blue_asymmetry_quality_thresholds(option, value, expected_flag):
     velocity = np.arange(-200, 201, 10) * u.km / u.s
     wavelengths = _wavelengths_from_velocity(velocity)
     profile = _flat_wing_profile(velocity, red_excess=2)
@@ -351,12 +319,11 @@ def test_calculate_red_blue_asymmetry_quality_thresholds(option, value, expected
     result = calculate_red_blue_asymmetry(
         cube,
         rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
         **{option: value},
     )
-
-    assert RBAQualityFlag(result["quality"].data[0, 0]).description == expected_reason
+    assert RBAQualityFlag(result["quality"].data[0, 0]) is expected_flag
     assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
 
 
@@ -368,8 +335,61 @@ def test_calculate_red_blue_asymmetry_real_cube_shape_and_coords(sns_sg_file):
         rest_wavelength=133.29 * u.nm,
         velocity_range=(20, 60) * u.km / u.s,
         velocity_window=80 * u.km / u.s,
-        interpolation_kind="linear",
+        degree=1,
     )
-
     assert result["red_blue_asymmetry"].shape == cube.shape[:-1]
     assert "time" in tuple(result["red_blue_asymmetry"].extra_coords.keys())
+
+
+def test_calculate_red_blue_asymmetry_rest_wavelength_required_without_meta():
+    cube = make_test_spectrogram_cube(np.ones((1, 1, 5)), np.arange(5) * u.nm)
+    with pytest.raises(ValueError, match="rest_wavelength"):
+        calculate_red_blue_asymmetry(cube, degree=1)
+
+
+def test_calculate_red_blue_asymmetry_explicit_rest_wavelength():
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    profile = _flat_wing_profile(velocity, red_excess=2)
+    cube = make_test_spectrogram_cube(profile.reshape(1, 1, -1), wavelengths)
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
+
+
+def test_calculate_red_blue_asymmetry_auto_detect_rest_wavelength():
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    profile = _flat_wing_profile(velocity, red_excess=2)
+    data = profile.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wavelengths)
+
+    header = fits.Header(cube.wcs.to_header())
+    header["INSTRUME"] = "IRIS"
+    header["TELESCOP"] = "IRIS"
+    header["DATA_LEV"] = 2
+    header["OBSID"] = 1
+    header["OBS_DESC"] = "Test obs"
+    header["NWIN"] = 1
+    header["TDESC1"] = "Si IV 1403"
+    header["TWAVE1"] = REST_WAVELENGTH.to(u.AA).value
+    header["TWMIN1"] = (wavelengths[0] - 0.5 * u.nm).to(u.AA).value
+    header["TWMAX1"] = (wavelengths[-1] + 0.5 * u.nm).to(u.AA).value
+    header["TDET1"] = "FUV2"
+    meta = SGMeta(header, "Si IV 1403", data_shape=data.shape)
+    cube.meta = meta
+
+    result = calculate_red_blue_asymmetry(cube, degree=1, center_on_peak=False)
+    assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
+    assert u.isclose(
+        result["red_blue_asymmetry"].meta["rba_rest_wavelength"] * u.nm,
+        REST_WAVELENGTH,
+        rtol=1e-4,
+    )
+
+
+def test_calculate_red_blue_asymmetry_auto_detect_on_real_data(sns_sg_file):
+    raster = read_files(sns_sg_file)
+    cube = raster["C II 1336"][0]
+    result = calculate_red_blue_asymmetry(cube, degree=1, center_on_peak=False)
+    assert "red_blue_asymmetry" in result
+    assert result["red_blue_asymmetry"].shape == cube.shape[:-1]


### PR DESCRIPTION
## Summary by Sourcery

Refine red–blue asymmetry and spectral moment analysis to better leverage cube metadata, improve API clarity, and factor out reusable spectrograph metadata helpers.

New Features:
- Allow red–blue asymmetry and moment calculations to auto-detect rest wavelength from spectrograph metadata when not passed explicitly.
- Expose convenience properties on spectrogram metadata and cubes, including temporal cadence, detector band, rest wavelength, spectral dispersion, solid angle, and wavelength-axis index.

Bug Fixes:
- Ensure red–blue asymmetry quality flags and error propagation behave robustly when interpolation fails, wings are incomplete, or profiles are saturated or low signal.
- Prevent invalid continuum window specifications and missing continuum points from silently producing incorrect red–blue asymmetry results.

Enhancements:
- Refactor red–blue asymmetry computation into smaller helpers for data preparation, profile windowing, interpolation, wing measurement, and per-pixel processing, improving readability and reuse.
- Simplify the red–blue asymmetry API by replacing the string-based interpolation kind with a numeric spline degree and always masking negative intensities.
- Make moment calculations more robust by auto-detecting the wavelength axis via a cube helper, handling quantity thresholds for intensity and saturation, and auto-computing velocity outputs when rest wavelength is known.
- Update radiometric calibration to use new spectrogram cube helpers for dispersion, solid angle, and detector band instead of duplicating WCS logic in the utility function.

Documentation:
- Clarify and expand docstrings and the red–blue asymmetry example to describe new defaults, metadata-driven rest wavelength detection, plotting of valid pixels, and interpretation of quality flags.

Tests:
- Extend and adjust unit tests for red–blue asymmetry, spectral moments, and metadata to cover continuum subtraction, error propagation, quality thresholds, rest-wavelength auto-detection, and the new spectrogram helper properties.
- Add dedicated tests for SGMeta/SJIMeta rest wavelength and detector band handling, and for spectrogram cube spectral dispersion and solid angle calculations.