### PR TITLE
Added more metadata properties.

### DIFF
--- a/changelog/142.feature.rst
+++ b/changelog/142.feature.rst
@@ -1,0 +1,1 @@
+Add ``rest_wavelength``, ``detector_band``, and ``temporal_cadence`` properties to the metadata.

--- a/changelog/142.feature.rst
+++ b/changelog/142.feature.rst
@@ -1,1 +1,1 @@
-Add ``rest_wavelength``, ``detector_band``, and ``temporal_cadence`` properties to the metadata.
+Exposed much more FITS metadata to the user via the ``meta``.

--- a/irispy/meta.py
+++ b/irispy/meta.py
@@ -3,6 +3,7 @@ import textwrap
 import numpy as np
 
 import astropy.units as u
+from astropy.constants import R_sun as _R_SUN
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 
@@ -53,6 +54,30 @@ class BaseMeta(NDMeta):
         return int(self.get("DATA_LEV"))
 
     @property
+    def camera(self):
+        """
+        IRIS camera ID - 1 for FUV, 2 for NUV/SJI.
+        """
+        return self.get("CAMERA")
+
+    @property
+    def sun_angular_radius(self):
+        """
+        Apparent angular radius of the Sun at the observer location.
+        """
+        rsun = self.get("RSUN_OBS")
+        if rsun is not None:
+            return float(rsun) * u.arcsec
+        return np.arctan(_R_SUN.to(u.m).value / float(self.get("DSUN_OBS"))) * u.rad
+
+    @property
+    def observer_radial_velocity(self):
+        """
+        Radial velocity of the observer relative to the Sun (m/s).
+        """
+        return float(self.get("OBS_VR")) * u.m / u.s
+
+    @property
     def distance_to_sun(self):
         return (self.get("DSUN_OBS") * u.m).to(u.AU)
 
@@ -67,6 +92,13 @@ class BaseMeta(NDMeta):
     @property
     def date_end(self):
         return self._construct_time("DATE_END")
+
+    @property
+    def temporal_cadence(self):
+        """
+        Average time between exposures.
+        """
+        return float(self.get("CADEX_AV")) * u.s
 
     @property
     def observing_mode_id(self):
@@ -148,6 +180,24 @@ class BaseMeta(NDMeta):
         return SPECTRAL_BAND.get(self.spectral_window, self.spectral_window)
 
     @property
+    def detector_band(self):
+        """
+        Detector band - ``'FUV'``, ``'NUV'``, or ``'SJI'``.
+        """
+        det_upper = self.detector.upper()
+        return next(
+            (band for band in ("FUV", "NUV", "SJI") if det_upper.startswith(band)),
+            det_upper,
+        )
+
+    @property
+    def rest_wavelength(self):
+        """
+        Rest wavelength of the spectral line for this window.
+        """
+        return (float(self.get(f"TWAVE{self._iwin}")) * u.AA).to(u.nm)
+
+    @property
     def raster_fov_width_y(self):
         """
         Width of the field of view of the raster in the Y (slit) direction.
@@ -203,6 +253,167 @@ class BaseMeta(NDMeta):
         if "fuv" in self.detector.lower():
             return self.get("SUMSPTRF")
         return self.get("SUMSPTRN")
+
+    @property
+    def exposure_time(self):
+        """
+        Mean exposure duration (shutter open time).
+        """
+        return float(self.get("EXPTIME")) * u.s
+
+    @property
+    def exposure_time_min(self):
+        """
+        Minimum exposure duration in this raster/SJI.
+        """
+        return float(self.get("EXPMIN")) * u.s
+
+    @property
+    def exposure_time_max(self):
+        """
+        Maximum exposure duration in this raster/SJI.
+        """
+        return float(self.get("EXPMAX")) * u.s
+
+    @property
+    def data_type(self):
+        """
+        Type of data, e.g. ``'Intensity'``.
+        """
+        return self.get("BTYPE")
+
+    @property
+    def data_unit(self):
+        """
+        Unit of the data values.
+        """
+        return self.get("BUNIT")
+
+    @property
+    def data_status(self):
+        """
+        Processing status.
+        """
+        return self.get("STATUS")
+
+    @property
+    def build_version(self):
+        """
+        Build version from ``jsoc_version.h``.
+        """
+        return self.get("BLD_VERS")
+
+    @property
+    def reformat_version(self):
+        """
+        Version of the software that reformatted the data to Level 2.
+        """
+        return self.get("VER_RF2")
+
+    @property
+    def reformat_date(self):
+        """
+        Date of reformatting to Level 2.
+        """
+        return self._construct_time("DATE_RF2")
+
+    @property
+    def observing_label(self):
+        """
+        Observing list string.
+        """
+        return self.get("OBSLABEL")
+
+    @property
+    def observing_title(self):
+        """
+        Title given by the planner.
+        """
+        return self.get("OBSTITLE")
+
+    @property
+    def lut_id(self):
+        """
+        Look-up table ID.
+        """
+        return self.get("LUTID")
+
+    @property
+    def number_of_exposures(self):
+        """
+        Number of exposures in this raster/SJI.
+        """
+        return self.get("NEXP")
+
+    @property
+    def number_of_exposures_planned(self):
+        """
+        Number of planned exposures in this raster/SJI.
+        """
+        return self.get("NEXP_PRP")
+
+    @property
+    def number_of_exposures_observation(self):
+        """
+        Expected total number of exposures in the whole observation.
+        """
+        return self.get("NEXPOBS")
+
+    @property
+    def number_of_saturated_pixels(self):
+        """
+        Number of saturated pixels.
+        """
+        return self.get("NSATPIX")
+
+    @property
+    def number_of_spikes(self):
+        """
+        Number of pixels identified as noise (cosmic-ray) spikes.
+        """
+        return self.get("NSPIKES")
+
+    @property
+    def percent_data(self):
+        """
+        Percentage of valid data values.
+        """
+        return self.get("PERCENTD")
+
+    @property
+    def data_mean(self):
+        """
+        Mean value of all pixels.
+        """
+        return self.get("DATAMEAN")
+
+    @property
+    def data_rms(self):
+        """
+        RMS deviation from the mean value of all pixels.
+        """
+        return self.get("DATARMS")
+
+    @property
+    def data_median(self):
+        """
+        Median value of all pixels.
+        """
+        return self.get("DATAMEDN")
+
+    @property
+    def data_min(self):
+        """
+        Minimum value of all pixels.
+        """
+        return self.get("DATAMIN")
+
+    @property
+    def data_max(self):
+        """
+        Maximum value of all pixels.
+        """
+        return self.get("DATAMAX")
 
 
 class SJIMeta(BaseMeta, RemoteSensorMetaABC):
@@ -267,6 +478,146 @@ class SGMeta(BaseMeta, SlitSpectrographMetaABC):
             )
         self._iwin = np.arange(len(spectral_windows))[window_mask][0] + 1
         self._fits_header = header
+
+    @property
+    def number_of_spectral_windows(self):
+        """
+        Number of spectral windows in this observation.
+        """
+        return self.get("NWIN")
+
+    @property
+    def raster_repetition(self):
+        """
+        Current raster repetition counter.
+        """
+        return self.get("RASRPT")
+
+    @property
+    def step_size_average(self):
+        """
+        Average of the basic raster step size.
+        """
+        return self.get("STEPS_AV")
+
+    @property
+    def step_size_stddev(self):
+        """
+        Standard deviation of the basic raster step size.
+        """
+        return self.get("STEPS_DV")
+
+    @property
+    def step_time_average(self):
+        """
+        Average of the basic raster step time.
+        """
+        return self.get("STEPT_AV")
+
+    @property
+    def step_time_stddev(self):
+        """
+        Standard deviation of the basic raster step time.
+        """
+        return self.get("STEPT_DV")
+
+    @property
+    def cadence_planned_average(self):
+        """
+        Mean cadence of the raster as planned.
+        """
+        return float(self.get("CADPL_AV")) * u.s
+
+    @property
+    def cadence_planned_stddev(self):
+        """
+        Standard deviation of the planned raster cadence.
+        """
+        return float(self.get("CADPL_DV")) * u.s
+
+    @property
+    def cadence_executed_stddev(self):
+        """
+        Standard deviation of the executed raster cadence.
+        """
+        return float(self.get("CADEX_DV")) * u.s
+
+    @property
+    def raster_type_index(self):
+        """
+        Raster type number.
+        """
+        return self.get("RASTYPDX")
+
+    @property
+    def raster_type_total(self):
+        """
+        Total number of raster types.
+        """
+        return self.get("RASTYPNX")
+
+    @property
+    def number_of_missing_raster_files(self):
+        """
+        Number of missing Level 1 files in this raster.
+        """
+        return self.get("MISSRAS")
+
+    @property
+    def number_of_missing_observation_files(self):
+        """
+        Number of missing Level 1 files in the whole observation.
+        """
+        return self.get("MISSOBS")
+
+    @property
+    def window_mean(self):
+        """
+        Mean value of all pixels in this spectral window.
+        """
+        return self.get(f"TDMEAN{self._iwin}")
+
+    @property
+    def window_rms(self):
+        """
+        RMS deviation from the mean value of all pixels in this spectral window.
+        """
+        return self.get(f"TDRMS{self._iwin}")
+
+    @property
+    def window_median(self):
+        """
+        Median value of all pixels in this spectral window.
+        """
+        return self.get(f"TDMEDN{self._iwin}")
+
+    @property
+    def window_min(self):
+        """
+        Minimum value of all pixels in this spectral window.
+        """
+        return self.get(f"TDMIN{self._iwin}")
+
+    @property
+    def window_max(self):
+        """
+        Maximum value of all pixels in this spectral window.
+        """
+        return self.get(f"TDMAX{self._iwin}")
+
+    @property
+    def window_saturated_pixels(self):
+        """
+        Number of saturated pixels in this spectral window.
+        """
+        return self.get(f"TSATPX{self._iwin}")
+
+    @property
+    def window_spikes(self):
+        """
+        Number of pixels identified as noise spikes in this spectral window.
+        """
+        return self.get(f"TSPIKE{self._iwin}")
 
     def __str__(self) -> str:
         return textwrap.dedent(

--- a/irispy/tests/test_meta.py
+++ b/irispy/tests/test_meta.py
@@ -1,0 +1,285 @@
+import astropy.units as u
+from astropy.io import fits
+
+from irispy.io.utils import read_files
+from irispy.meta import SGMeta, SJIMeta
+
+
+def _make_sg_header():
+    header = fits.Header()
+    header["INSTRUME"] = "IRIS"
+    header["TELESCOP"] = "IRIS"
+    header["DATA_LEV"] = 2
+    header["OBSID"] = 1
+    header["OBS_DESC"] = "Test obs"
+    header["NWIN"] = 1
+    header["TDESC1"] = "Si IV 1403"
+    header["TWAVE1"] = 1402.77
+    header["TWMIN1"] = 1398.61
+    header["TWMAX1"] = 1406.03
+    header["TDET1"] = "FUV2"
+    return header
+
+
+def test_sgmeta_rest_wavelength():
+    meta = SGMeta(_make_sg_header(), "Si IV 1403")
+    assert meta.rest_wavelength.unit == u.nm
+    assert u.isclose(meta.rest_wavelength, 140.277 * u.nm, rtol=1e-4)
+
+
+def test_sgmeta_detector_band_fuv():
+    meta = SGMeta(_make_sg_header(), "Si IV 1403")
+    assert meta.detector_band == "FUV"
+
+
+def test_sgmeta_detector_band_nuv():
+    header = _make_sg_header()
+    header["TDET1"] = "NUV"
+    meta = SGMeta(header, "Si IV 1403")
+    assert meta.detector_band == "NUV"
+
+
+def test_sgmeta_detector_band_sji():
+    header = fits.Header()
+    header["INSTRUME"] = "IRIS"
+    header["TELESCOP"] = "IRIS"
+    header["TDET1"] = "SJI"
+    header["TDESC1"] = "SJI_1330"
+    header["TWAVE1"] = 1330.0
+    header["TWMIN1"] = 1330.0
+    header["TWMAX1"] = 1330.0
+    meta = SJIMeta(header)
+    assert meta.detector_band == "SJI"
+
+
+def test_sgmeta_temporal_cadence():
+    header = _make_sg_header()
+    header["CADEX_AV"] = 9.264
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    cadence = meta.temporal_cadence
+    assert u.isclose(cadence, 9.264 * u.s, rtol=1e-4)
+
+
+def test_sgmeta_real_sns_data(sns_sg_file):
+    raster = read_files(sns_sg_file)
+    cube = raster["Si IV 1403"][0]
+    meta = cube.meta
+
+    assert meta.detector_band == "FUV"
+    assert meta.rest_wavelength.unit == u.nm
+    assert u.isclose(meta.rest_wavelength, 140.277 * u.nm, rtol=1e-3)
+    assert meta.temporal_cadence.unit.is_equivalent(u.s)
+    assert meta.camera == 1
+    assert meta.number_of_spectral_windows is not None
+
+
+def test_sgmeta_camera():
+    header = _make_sg_header()
+    header["CAMERA"] = 1
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.camera == 1
+
+
+def test_sgmeta_sun_angular_radius_from_rsun():
+    header = _make_sg_header()
+    header["RSUN_OBS"] = 975.0
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert u.isclose(meta.sun_angular_radius, 975.0 * u.arcsec)
+
+
+def test_sgmeta_sun_angular_radius_from_dsun():
+    header = _make_sg_header()
+    header["DSUN_OBS"] = 1.5e11
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    radius = meta.sun_angular_radius
+    assert radius.unit.is_equivalent(u.arcsec)
+
+
+def test_sgmeta_observer_radial_velocity():
+    header = _make_sg_header()
+    header["OBS_VR"] = 3500.0
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert u.isclose(meta.observer_radial_velocity, 3500.0 * u.m / u.s)
+
+
+def test_sgmeta_number_of_spectral_windows():
+    meta = SGMeta(_make_sg_header(), "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.number_of_spectral_windows == 1
+
+
+def test_sgmeta_raster_repetition():
+    header = _make_sg_header()
+    header["RASRPT"] = 3
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.raster_repetition == 3
+
+
+def test_meta_exposure_time():
+    header = _make_sg_header()
+    header["EXPTIME"] = 12.5
+    header["EXPMIN"] = 10.0
+    header["EXPMAX"] = 15.0
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert u.isclose(meta.exposure_time, 12.5 * u.s)
+    assert u.isclose(meta.exposure_time_min, 10.0 * u.s)
+    assert u.isclose(meta.exposure_time_max, 15.0 * u.s)
+
+
+def test_meta_data_type_and_unit():
+    header = _make_sg_header()
+    header["BTYPE"] = "Intensity"
+    header["BUNIT"] = "DN/s"
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.data_type == "Intensity"
+    assert meta.data_unit == "DN/s"
+
+
+def test_meta_data_status():
+    header = _make_sg_header()
+    header["STATUS"] = "Final"
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.data_status == "Final"
+
+
+def test_meta_build_and_reformat_info():
+    header = _make_sg_header()
+    header["BLD_VERS"] = "v9.4"
+    header["VER_RF2"] = "1.2.3"
+    header["DATE_RF2"] = "2024-01-15T10:30:00"
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.build_version == "v9.4"
+    assert meta.reformat_version == "1.2.3"
+    assert meta.reformat_date.scale == "utc"
+
+
+def test_meta_observing_label_and_title():
+    header = _make_sg_header()
+    header["OBSLABEL"] = "OBS_12345"
+    header["OBSTITLE"] = "Test Campaign"
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.observing_label == "OBS_12345"
+    assert meta.observing_title == "Test Campaign"
+
+
+def test_meta_lut_id():
+    header = _make_sg_header()
+    header["LUTID"] = 7
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.lut_id == 7
+
+
+def test_meta_number_of_exposures():
+    header = _make_sg_header()
+    header["NEXP"] = 180
+    header["NEXP_PRP"] = 200
+    header["NEXPOBS"] = 400
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.number_of_exposures == 180
+    assert meta.number_of_exposures_planned == 200
+    assert meta.number_of_exposures_observation == 400
+
+
+def test_meta_data_quality_counts():
+    header = _make_sg_header()
+    header["NSATPIX"] = 42
+    header["NSPIKES"] = 15
+    header["PERCENTD"] = 98.5
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.number_of_saturated_pixels == 42
+    assert meta.number_of_spikes == 15
+    assert meta.percent_data == 98.5
+
+
+def test_meta_data_statistics():
+    header = _make_sg_header()
+    header["DATAMEAN"] = 120.5
+    header["DATARMS"] = 45.2
+    header["DATAMEDN"] = 110.0
+    header["DATAMIN"] = 5.0
+    header["DATAMAX"] = 500.0
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.data_mean == 120.5
+    assert meta.data_rms == 45.2
+    assert meta.data_median == 110.0
+    assert meta.data_min == 5.0
+    assert meta.data_max == 500.0
+
+
+def test_sgmeta_raster_step_properties():
+    header = _make_sg_header()
+    header["STEPS_AV"] = 0.35
+    header["STEPS_DV"] = 0.02
+    header["STEPT_AV"] = 18.5
+    header["STEPT_DV"] = 1.2
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.step_size_average == 0.35
+    assert meta.step_size_stddev == 0.02
+    assert meta.step_time_average == 18.5
+    assert meta.step_time_stddev == 1.2
+
+
+def test_sgmeta_cadence_planned():
+    header = _make_sg_header()
+    header["CADPL_AV"] = 15.0
+    header["CADPL_DV"] = 0.5
+    header["CADEX_DV"] = 0.3
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert u.isclose(meta.cadence_planned_average, 15.0 * u.s)
+    assert u.isclose(meta.cadence_planned_stddev, 0.5 * u.s)
+    assert u.isclose(meta.cadence_executed_stddev, 0.3 * u.s)
+
+
+def test_sgmeta_raster_type():
+    header = _make_sg_header()
+    header["RASTYPDX"] = 3
+    header["RASTYPNX"] = 8
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.raster_type_index == 3
+    assert meta.raster_type_total == 8
+
+
+def test_sgmeta_missing_files():
+    header = _make_sg_header()
+    header["MISSRAS"] = 2
+    header["MISSOBS"] = 5
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.number_of_missing_raster_files == 2
+    assert meta.number_of_missing_observation_files == 5
+
+
+def test_sgmeta_window_statistics():
+    header = _make_sg_header()
+    header["TDMEAN1"] = 150.0
+    header["TDRMS1"] = 30.0
+    header["TDMEDN1"] = 145.0
+    header["TDMIN1"] = 10.0
+    header["TDMAX1"] = 400.0
+    header["TSATPX1"] = 3
+    header["TSPIKE1"] = 7
+    meta = SGMeta(header, "Si IV 1403", data_shape=(10, 2, 2))
+    assert meta.window_mean == 150.0
+    assert meta.window_rms == 30.0
+    assert meta.window_median == 145.0
+    assert meta.window_min == 10.0
+    assert meta.window_max == 400.0
+    assert meta.window_saturated_pixels == 3
+    assert meta.window_spikes == 7
+
+
+def test_sjmeta_base_properties():
+    header = fits.Header()
+    header["INSTRUME"] = "IRIS"
+    header["TELESCOP"] = "IRIS"
+    header["DATA_LEV"] = 2
+    header["TDET1"] = "SJI"
+    header["TDESC1"] = "SJI_1330"
+    header["TWAVE1"] = 1330.0
+    header["TWMIN1"] = 1330.0
+    header["TWMAX1"] = 1330.0
+    header["EXPTIME"] = 8.0
+    header["BTYPE"] = "Intensity"
+    header["NSATPIX"] = 0
+    meta = SJIMeta(header, data_shape=(10, 10))
+    assert u.isclose(meta.exposure_time, 8.0 * u.s)
+    assert meta.data_type == "Intensity"
+    assert meta.number_of_saturated_pixels == 0


### PR DESCRIPTION
…o metadata

- Add BaseMeta.temporal_cadence property
- Add SGMeta.detector_band property (FUV/NUV/SJI from detector name)
- Add SGMeta.rest_wavelength property (from TWAVE<n> FITS keyword, in nm)
- Add tests for all new properties

## Summary by Sourcery

Extend IRIS metadata classes with richer accessors for instrument configuration, observation cadence, data quality, and spectral window characteristics.

New Features:
- Expose temporal_cadence on metadata using the average cadence header keyword.
- Add detector_band property to classify IRIS detectors into FUV, NUV, or SJI based on header values.
- Add rest_wavelength property for spectral windows derived from TWAVE<n> FITS keywords and returned in nanometers.
- Provide additional metadata accessors for camera, sun angular radius, observer radial velocity, exposure characteristics, data type/unit/status, build/reformat info, observing labels, LUT ID, exposure counts, data quality counts, and global data statistics.
- Expose SGMeta raster and window-level properties including window statistics, cadence planning/execution metrics, raster repetition/type, missing file counts, and number of spectral windows.

Documentation:
- Document the new IRIS metadata accessors in a changelog entry for this feature.

Tests:
- Add unit tests for new metadata properties including detector_band, rest_wavelength, temporal_cadence, and extended SGMeta/SJIMeta header accessors, including tests against real SNS data.