### PR TITLE
Red blue refactor

### DIFF
--- a/changelog/140.breaking.rst
+++ b/changelog/140.breaking.rst
@@ -1,0 +1,3 @@
+`irispy.utils.calculate_red_blue_asymmetry` now takes ``degree`` instead of ``interpolation_kind``.
+Removed ``mask_negative`` as it is now always masked.
+``rest_wavelength`` defaults to ``None`` as we now get the value from the cube metadata.

--- a/changelog/140.breaking.rst
+++ b/changelog/140.breaking.rst
@@ -1,3 +1,4 @@
 `irispy.utils.calculate_red_blue_asymmetry` now takes ``degree`` instead of ``interpolation_kind``.
 Removed ``mask_negative`` as it is now always masked.
 ``rest_wavelength`` defaults to ``None`` as we now get the value from the cube metadata.
+Removed ``uncertainty``, ``center_on_peak``, ``velocity_window``, and ``fit_window`` from ``calculate_red_blue_asymmetry``.

--- a/changelog/140.breaking.rst
+++ b/changelog/140.breaking.rst
@@ -1,3 +1,4 @@
 Simplified `irispy.utils.calculate_red_blue_asymmetry` by removing low-level tuning arguments that are now handled internally.
 The function now always centers profiles on the line peak, uses uncertainty from the input cube when available, and derives its interpolation window from ``velocity_range``.
 The function now takes ``degree`` instead of ``interpolation_kind``, removed ``mask_negative`` as it is now always masked, removed ``uncertainty``, ``center_on_peak``, ``velocity_window``, and ``fit_window`` as well.
+The output now contains only the red-blue asymmetry map, quality map, optional uncertainty map, and optional profile cubes.

--- a/changelog/140.breaking.rst
+++ b/changelog/140.breaking.rst
@@ -1,4 +1,3 @@
-`irispy.utils.calculate_red_blue_asymmetry` now takes ``degree`` instead of ``interpolation_kind``.
-Removed ``mask_negative`` as it is now always masked.
-``rest_wavelength`` defaults to ``None`` as we now get the value from the cube metadata.
-Removed ``uncertainty``, ``center_on_peak``, ``velocity_window``, and ``fit_window`` from ``calculate_red_blue_asymmetry``.
+Simplified `irispy.utils.calculate_red_blue_asymmetry` by removing low-level tuning arguments that are now handled internally.
+The function now always centers profiles on the line peak, uses uncertainty from the input cube when available, and derives its interpolation window from ``velocity_range``.
+The function now takes ``degree`` instead of ``interpolation_kind``, removed ``mask_negative`` as it is now always masked, removed ``uncertainty``, ``center_on_peak``, ``velocity_window``, and ``fit_window`` as well.

--- a/changelog/144.breaking.rst
+++ b/changelog/144.breaking.rst
@@ -1,4 +1,4 @@
-Simplified `irispy.utils.calculate_red_blue_asymmetry` by removing low-level tuning arguments that are now handled internally.
+Simplified `irispy.utils.red_blue.calculate_red_blue_asymmetry` by removing low-level tuning arguments that are now handled internally.
 The function now always centers profiles on the line peak, uses uncertainty from the input cube when available, and derives its interpolation window from ``velocity_range``.
 The function now takes ``degree`` instead of ``interpolation_kind``, removed ``mask_negative`` as it is now always masked, removed ``uncertainty``, ``center_on_peak``, ``velocity_window``, and ``fit_window`` as well.
 The output now contains only the red-blue asymmetry map, quality map, optional uncertainty map, and optional profile cubes.

--- a/changelog/144.breaking.rst
+++ b/changelog/144.breaking.rst
@@ -1,4 +1,4 @@
 Simplified `irispy.utils.red_blue.calculate_red_blue_asymmetry` by removing low-level tuning arguments that are now handled internally.
 The function now always centers profiles on the line peak, uses uncertainty from the input cube when available, and derives its interpolation window from ``velocity_range``.
-The function now takes ``degree`` instead of ``interpolation_kind``, removed ``mask_negative`` as it is now always masked, removed ``uncertainty``, ``center_on_peak``, ``velocity_window``, and ``fit_window`` as well.
+The function now takes ``degree`` instead of ``interpolation_kind``, and removes ``mask_negative`` (now always applied), ``uncertainty``, ``center_on_peak``, ``velocity_window``, and ``fit_window``.
 The output now contains only the red-blue asymmetry map, quality map, optional uncertainty map, and optional profile cubes.

--- a/examples/analysis/05_red_blue_asymmetry.py
+++ b/examples/analysis/05_red_blue_asymmetry.py
@@ -20,7 +20,7 @@ import astropy.units as u
 from astropy.visualization import time_support
 
 from irispy.io import read_files
-from irispy.utils.red_blue import calculate_red_blue_asymmetry
+from irispy.utils.red_blue import RBAQualityFlag, calculate_red_blue_asymmetry
 
 time_support()
 
@@ -64,9 +64,10 @@ velocity_range = (25, 75) * u.km / u.s
 # Ignore pixels where the line peak is too weak for a useful wing comparison.
 min_intensity = 75 * si_iv.unit
 
+# rest_wavelength is auto-detected from the cube metadata (TWAVE[N] FITS keyword).
+# You can also pass it explicitly: rest_wavelength=si_iv_rest.
 red_blue = calculate_red_blue_asymmetry(
     si_iv,
-    rest_wavelength=si_iv_rest,
     velocity_range=velocity_range,
     min_intensity=min_intensity,
     return_profiles=True,
@@ -102,7 +103,8 @@ axes = [
 
 # This plot will be the RBA values over the full raster.
 ax = axes[0]
-rba_map = np.where(quality.data == 0, asymmetry.data, np.nan)
+rba_map = np.where(quality.data == int(RBAQualityFlag.OK), asymmetry.data, np.nan)
+# Colour scale: 98th percentile of absolute RBA, floored so subtle features remain visible.
 vmax = max(np.nanpercentile(np.abs(rba_map), 98), 0.15)
 im = ax.imshow(rba_map, cmap="RdBu_r", origin="lower", aspect="auto", vmin=-vmax, vmax=vmax)
 ax.plot(

--- a/examples/analysis/05_red_blue_asymmetry.py
+++ b/examples/analysis/05_red_blue_asymmetry.py
@@ -74,7 +74,6 @@ red_blue = calculate_red_blue_asymmetry(
 )
 
 asymmetry = red_blue["red_blue_asymmetry"]
-peak_velocity = red_blue["peak_velocity"]
 quality = red_blue["quality"]
 observed_profiles = red_blue["observed_profile"]
 
@@ -132,9 +131,7 @@ ax.axvspan(-v_high, -v_low, color="C0", alpha=0.1)
 ax.axvspan(v_low, v_high, color="C3", alpha=0.1)
 
 ax.set_title(
-    f"RBA = {float(asymmetry.data[selected_pixel_index]):.2f}   "
-    f"Peak vel = {float(peak_velocity.data[selected_pixel_index]):.1f} km/s   "
-    f"Quality = {int(quality.data[selected_pixel_index]):d}"
+    f"RBA = {float(asymmetry.data[selected_pixel_index]):.2f}   Quality = {int(quality.data[selected_pixel_index]):d}"
 )
 ax.set_xlabel("Velocity [km/s]")
 ax.set_ylabel(f"Intensity [{si_iv.unit.to_string()}]")

--- a/irispy/tests/figure_hashes_mpl_3108_ft_261_astropy_720.json
+++ b/irispy/tests/figure_hashes_mpl_3108_ft_261_astropy_720.json
@@ -1,6 +1,7 @@
 {
   "irispy.utils.tests.test_dust.test_remove_dust_before_after_figure": "bbbeb47b8b0b81901f87be8ee1553fad5ed1683ade20bce1155d26a3f2644088",
   "irispy.utils.tests.test_moments.test_calculate_moments_known_gaussian_figure": "9723b475774b4e71c55f00f0692667bda86eaaddf1efc4883cefb05c492ce755",
+  "irispy.utils.tests.test_red_blue.test_calculate_red_blue_asymmetry_continuum_figure": "1fb0dba7925ca3a8e4eed3fbb59e5f66498cf919b64365e58b4a55384fe8f0b8",
   "irispy.utils.tests.test_response.test_plot_idl_vs_python_fuv_sg": "ba253be18e2552c2d3e9c73ed70f123cf0516fbe5b96315ace3a03536f35b2b6",
   "irispy.utils.tests.test_response.test_plot_idl_vs_python_nuv_sg": "3eca254b88254afb59b11ce0ff42206e429acc5641111e3da97aa3a2c6cb2122",
   "irispy.utils.tests.test_response.test_plot_idl_vs_python_sji_1": "1a4bcb4a066913096c50eaa179b0e8a17c76bca79581a9420516d64b083b0b3f",

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -393,12 +393,14 @@ def calculate_red_blue_asymmetry(
     if rest_wavelength is None:
         try:
             rest_wavelength = cube.meta.rest_wavelength
-        except (AttributeError, TypeError) as exc:
+        except AttributeError as exc:
+            pass
+        if rest_wavelength is None:
             msg = (
                 "rest_wavelength was not provided and could not be read from cube.meta. "
                 "Pass rest_wavelength explicitly or provide a cube with SGMeta containing TWAVE keywords."
             )
-            raise ValueError(msg) from exc
+            raise ValueError(msg)
     rest_wavelength = u.Quantity(rest_wavelength).to(u.nm)
 
     velocity_range = u.Quantity(velocity_range).to(u.km / u.s)

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -3,6 +3,7 @@ Red-blue asymmetry utilities for IRIS spectrogram cubes.
 """
 
 import warnings
+import contextlib
 from enum import IntEnum
 from dataclasses import dataclass
 
@@ -114,16 +115,13 @@ class _PixelProfileDetail:
 class _RBAContext:
     velocity: np.ndarray
     interp_velocity: np.ndarray
-    center_on_peak: bool
-    fit_window: float
-    d_velocity: float
     degree: int
     red_mask: np.ndarray
     blue_mask: np.ndarray
     min_wing_coverage: float
 
 
-def _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows, uncertainty):
+def _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows):
     """
     Extract data/errors, mask negatives, subtract continuum, move spectral axis to -1.
     """
@@ -132,12 +130,7 @@ def _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows, uncerta
         data = np.where(cube.mask, np.nan, data)
     data = np.where(data < 0, np.nan, data)
 
-    if uncertainty is not None:
-        errors = u.Quantity(uncertainty, cube.unit).to_value(cube.unit)
-    elif cube.uncertainty is not None:
-        errors = np.asarray(cube.uncertainty.array, dtype=float)
-    else:
-        errors = None
+    errors = np.asarray(cube.uncertainty.array, dtype=float) if cube.uncertainty is not None else None
     if errors is not None and cube.mask is not None:
         errors = np.where(cube.mask, np.nan, errors)
 
@@ -169,26 +162,10 @@ def _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows, uncerta
     return data, errors
 
 
-def _window_profile(profile, profile_error, velocity, peak_index, *, center_on_peak, fit_window, d_velocity):
-    if center_on_peak:
-        if peak_index == 0 or peak_index == profile.size - 1:
-            return None, None, None, RBAQualityFlag.PEAK_AT_EDGE
-        window_pixels = profile.size if d_velocity == 0 else int(fit_window / abs(d_velocity))
-        low_idx = max(0, peak_index - window_pixels)
-        high_idx = min(profile.size, peak_index + window_pixels)
-        fit_slice = slice(low_idx, high_idx)
-        shifted_velocity = velocity[fit_slice] - velocity[peak_index]
-        profile = profile[fit_slice]
-        if profile_error is not None:
-            profile_error = profile_error[fit_slice]
-    else:
-        fit_mask = np.abs(velocity) <= fit_window
-        shifted_velocity = velocity[fit_mask]
-        profile = profile[fit_mask]
-        if profile_error is not None:
-            profile_error = profile_error[fit_mask]
-
-    return shifted_velocity, profile, profile_error, RBAQualityFlag.OK
+def _center_profile_on_peak(profile, profile_error, velocity, peak_index):
+    if peak_index == 0 or peak_index == profile.size - 1:
+        return None, None, None, RBAQualityFlag.PEAK_AT_EDGE
+    return velocity - velocity[peak_index], profile, profile_error, RBAQualityFlag.OK
 
 
 def _interpolate_profile_and_error(shifted_velocity, profile, profile_error, interp_velocity, degree):
@@ -276,14 +253,11 @@ def _process_pixel(profile, profile_error, ctx: _RBAContext):
     peak_index = np.nanargmax(np.where(finite_profile, profile, np.nan))
     peak_velocity = ctx.velocity[peak_index]
 
-    shifted_velocity, profile, profile_error, quality = _window_profile(
+    shifted_velocity, profile, profile_error, quality = _center_profile_on_peak(
         profile,
         profile_error,
         ctx.velocity,
         peak_index,
-        center_on_peak=ctx.center_on_peak,
-        fit_window=ctx.fit_window,
-        d_velocity=ctx.d_velocity,
     )
     if quality is not RBAQualityFlag.OK:
         return _PixelCoreResult(quality=quality, peak_velocity=peak_velocity), None
@@ -326,12 +300,8 @@ def calculate_red_blue_asymmetry(
     *,
     rest_wavelength=None,
     velocity_range=(50, 150) * u.km / u.s,
-    velocity_window=None,
-    fit_window=None,
     dv=10 * u.km / u.s,
-    center_on_peak=True,
     continuum_windows=None,
-    uncertainty=None,
     degree=3,
     min_intensity=None,
     saturation_limit=None,
@@ -355,24 +325,11 @@ def calculate_red_blue_asymmetry(
         `~irispy.meta.SGMeta` instance with a ``TWAVE<n>`` FITS keyword).
     velocity_range : `astropy.units.Quantity`, optional
         Two positive velocities defining the wing range to average.
-    velocity_window : `astropy.units.Quantity`, optional
-        Symmetric interpolation window about zero velocity. Defaults to the
-        high end of ``velocity_range`` plus 50 km/s.
-    fit_window : `astropy.units.Quantity`, optional
-        Velocity half-width used to crop the source profile before
-        interpolation. Defaults to the high end of ``velocity_range`` plus
-        100 km/s.
     dv : `astropy.units.Quantity`, optional
         Velocity spacing for the interpolated profile.
-    center_on_peak : `bool`, optional
-        If `True`, shift each profile so its peak lies at zero velocity before
-        sampling the wings.
     continuum_windows : `astropy.units.Quantity`, optional
         One or more wavelength windows used to estimate and subtract a
         continuum.
-    uncertainty : `astropy.units.Quantity`, optional
-        Per-bin intensity uncertainty. If omitted, ``cube.uncertainty`` is
-        used when available.
     degree : `int`, optional
         Spline degree for `scipy.interpolate.make_interp_spline`.
     min_intensity : `float` or `astropy.units.Quantity`, optional
@@ -391,10 +348,8 @@ def calculate_red_blue_asymmetry(
     `irispy.spectrograph.RasterCollection`
     """
     if rest_wavelength is None:
-        try:
+        with contextlib.suppress(AttributeError):
             rest_wavelength = cube.meta.rest_wavelength
-        except AttributeError as exc:
-            pass
         if rest_wavelength is None:
             msg = (
                 "rest_wavelength was not provided and could not be read from cube.meta. "
@@ -402,6 +357,9 @@ def calculate_red_blue_asymmetry(
             )
             raise ValueError(msg)
     rest_wavelength = u.Quantity(rest_wavelength).to(u.nm)
+    if rest_wavelength.shape != () or not np.isfinite(rest_wavelength.value) or rest_wavelength <= 0 * u.nm:
+        msg = "rest_wavelength must be a positive finite scalar wavelength"
+        raise ValueError(msg)
 
     velocity_range = u.Quantity(velocity_range).to(u.km / u.s)
     if velocity_range.shape != (2,):
@@ -412,19 +370,7 @@ def calculate_red_blue_asymmetry(
         msg = "velocity_range must be positive and increasing"
         raise ValueError(msg)
 
-    velocity_window = (
-        velocity_high + 50 * u.km / u.s if velocity_window is None else u.Quantity(velocity_window)
-    ).to_value(u.km / u.s)
-    fit_window = (velocity_high + 100 * u.km / u.s if fit_window is None else u.Quantity(fit_window)).to_value(
-        u.km / u.s
-    )
     dv = u.Quantity(dv).to_value(u.km / u.s)
-    if velocity_window <= velocity_high.to_value(u.km / u.s):
-        msg = "velocity_window must be larger than velocity_range high end"
-        raise ValueError(msg)
-    if fit_window <= velocity_window:
-        msg = "fit_window must be larger than velocity_window"
-        raise ValueError(msg)
     if dv <= 0:
         msg = "dv must be positive"
         raise ValueError(msg)
@@ -441,13 +387,13 @@ def calculate_red_blue_asymmetry(
     wavelengths = cube.axis_world_coords(wavelength_axis)[0].to(u.nm)
     rest_wavelength = rest_wavelength.to(wavelengths.unit)
     velocity = ((wavelengths - rest_wavelength) / rest_wavelength * constants.c).to_value(u.km / u.s)
-    interp_velocity = np.arange(-velocity_window, velocity_window + dv, dv)
+    interp_extent = velocity_high.to_value(u.km / u.s)
+    interp_velocity = np.arange(-interp_extent, interp_extent + dv, dv)
     velocity_range_kms = (velocity_low.to_value(u.km / u.s), velocity_high.to_value(u.km / u.s))
 
-    data, errors = _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows, uncertainty)
+    data, errors = _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows)
 
     output_shape = data.shape[:-1]
-    d_velocity = float(np.nanmean(np.diff(velocity))) if velocity.size > 1 else 1.0
 
     low, high = velocity_range_kms
     red_mask = (interp_velocity >= low) & (interp_velocity <= high)
@@ -456,9 +402,6 @@ def calculate_red_blue_asymmetry(
     ctx = _RBAContext(
         velocity=velocity,
         interp_velocity=interp_velocity,
-        center_on_peak=center_on_peak,
-        fit_window=fit_window,
-        d_velocity=d_velocity,
         degree=degree,
         red_mask=red_mask,
         blue_mask=blue_mask,
@@ -522,10 +465,7 @@ def calculate_red_blue_asymmetry(
         "rba_rest_wavelength": rest_wavelength.to_value(u.nm),
         "rba_rest_wavelength_unit": "nm",
         "rba_velocity_range": velocity_range_kms,
-        "rba_velocity_window": velocity_window,
-        "rba_fit_window": fit_window,
         "rba_dv": dv,
-        "rba_center_on_peak": center_on_peak,
         "rba_interpolation_degree": degree,
     }
     if continuum_windows is not None:

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -3,9 +3,7 @@ Red-blue asymmetry utilities for IRIS spectrogram cubes.
 """
 
 import warnings
-import contextlib
 from enum import IntEnum
-from dataclasses import dataclass
 
 import numpy as np
 from scipy.interpolate import make_interp_spline
@@ -92,35 +90,6 @@ def _make_profile_cube(cube, *, data, velocity_grid, wavelength_axis, meta, unce
     )
 
 
-@dataclass
-class _PixelCoreResult:
-    quality: RBAQualityFlag
-    rba: float = np.nan
-    red_wing: float = np.nan
-    blue_wing: float = np.nan
-    peak_intensity: float = np.nan
-    peak_velocity: float = np.nan
-    red_blue_error: float = np.nan
-    red_wing_error: float = np.nan
-    blue_wing_error: float = np.nan
-
-
-@dataclass
-class _PixelProfileDetail:
-    interp_profile: np.ndarray
-    interp_error: np.ndarray | None = None
-
-
-@dataclass
-class _RBAContext:
-    velocity: np.ndarray
-    interp_velocity: np.ndarray
-    degree: int
-    red_mask: np.ndarray
-    blue_mask: np.ndarray
-    min_wing_coverage: float
-
-
 def _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows):
     """
     Extract data/errors, mask negatives, subtract continuum, move spectral axis to -1.
@@ -160,139 +129,6 @@ def _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows):
             errors = np.sqrt(errors**2 + continuum_errors[..., np.newaxis] ** 2)
 
     return data, errors
-
-
-def _center_profile_on_peak(profile, profile_error, velocity, peak_index):
-    if peak_index == 0 or peak_index == profile.size - 1:
-        return None, None, None, RBAQualityFlag.PEAK_AT_EDGE
-    return velocity - velocity[peak_index], profile, profile_error, RBAQualityFlag.OK
-
-
-def _interpolate_profile_and_error(shifted_velocity, profile, profile_error, interp_velocity, degree):
-    finite = np.isfinite(shifted_velocity) & np.isfinite(profile)
-    min_points = degree + 1
-    if finite.sum() < min_points:
-        return None, None, RBAQualityFlag.TOO_FEW_POINTS
-
-    sv, sp = shifted_velocity[finite], profile[finite]
-    order = np.argsort(sv)
-    ordered_velocity, ordered_profile = sv[order], sp[order]
-
-    try:
-        interp_profile = make_interp_spline(ordered_velocity, ordered_profile, k=degree)(
-            interp_velocity, extrapolate=False
-        )
-    except ValueError:
-        return None, None, RBAQualityFlag.INTERP_FAILED
-
-    interp_error = None
-    if profile_error is not None:
-        ordered_error = profile_error[finite][order]
-        finite_error = np.isfinite(ordered_error)
-        if finite_error.sum() >= min_points:
-            try:
-                interp_error = make_interp_spline(
-                    ordered_velocity[finite_error], ordered_error[finite_error], k=degree
-                )(interp_velocity, extrapolate=False)
-                interp_error = np.where(interp_error >= 0, interp_error, np.nan)
-            except ValueError:
-                return None, None, RBAQualityFlag.INTERP_FAILED
-
-    return interp_profile, interp_error, RBAQualityFlag.OK
-
-
-def _compute_wings_and_peak(interp_profile, red_mask, blue_mask, min_wing_coverage):
-    red_finite = red_mask & np.isfinite(interp_profile)
-    blue_finite = blue_mask & np.isfinite(interp_profile)
-    if red_finite.sum() < min_wing_coverage * red_mask.sum() or blue_finite.sum() < min_wing_coverage * blue_mask.sum():
-        return np.nan, np.nan, np.nan, RBAQualityFlag.INCOMPLETE_WINGS
-
-    red_intensity = np.nanmean(interp_profile[red_finite]) if red_finite.any() else np.nan
-    blue_intensity = np.nanmean(interp_profile[blue_finite]) if blue_finite.any() else np.nan
-    peak = np.nanmax(interp_profile)
-    if not np.isfinite(peak) or np.isclose(peak, 0):
-        return np.nan, np.nan, np.nan, RBAQualityFlag.PEAK_IS_ZERO
-
-    return red_intensity, blue_intensity, peak, RBAQualityFlag.OK
-
-
-def _propagate_rba_error(red_intensity, blue_intensity, peak, interp_error, red_mask, blue_mask, interp_profile):
-    """Propagate uncertainties through ``(I_R - I_B) / I_p``."""
-    if interp_error is None:
-        return np.nan, np.nan, np.nan
-
-    n_red = np.isfinite(interp_error[red_mask]).sum()
-    n_blue = np.isfinite(interp_error[blue_mask]).sum()
-    red_err = np.sqrt(np.nansum(interp_error[red_mask] ** 2)) / n_red if n_red > 0 else np.nan
-    blue_err = np.sqrt(np.nansum(interp_error[blue_mask] ** 2)) / n_blue if n_blue > 0 else np.nan
-    peak_err = interp_error[np.nanargmax(interp_profile)]
-    numerator = red_intensity - blue_intensity
-    num_err = np.sqrt(red_err**2 + blue_err**2)
-
-    rba_error = np.nan
-    numerator_is_zero = np.isclose(numerator, 0)
-    if np.isfinite(num_err) and (numerator_is_zero or np.isfinite(peak_err)):
-        variance = (num_err / peak) ** 2
-        if not numerator_is_zero:
-            variance += (numerator * peak_err / peak**2) ** 2
-        rba_error = np.sqrt(variance)
-
-    return rba_error, red_err, blue_err
-
-
-def _process_pixel(profile, profile_error, ctx: _RBAContext):
-    """
-    Compute RBA for a single spatial pixel.
-
-    Returns (``_PixelCoreResult``, ``_PixelProfileDetail | None``).
-    """
-    finite_profile = np.isfinite(profile)
-    if not finite_profile.any():
-        return _PixelCoreResult(quality=RBAQualityFlag.NO_FINITE_DATA), None
-
-    peak_index = np.nanargmax(np.where(finite_profile, profile, np.nan))
-    peak_velocity = ctx.velocity[peak_index]
-
-    shifted_velocity, profile, profile_error, quality = _center_profile_on_peak(
-        profile,
-        profile_error,
-        ctx.velocity,
-        peak_index,
-    )
-    if quality is not RBAQualityFlag.OK:
-        return _PixelCoreResult(quality=quality, peak_velocity=peak_velocity), None
-
-    interp_profile, interp_error, interp_quality = _interpolate_profile_and_error(
-        shifted_velocity, profile, profile_error, ctx.interp_velocity, ctx.degree
-    )
-    detail = _PixelProfileDetail(interp_profile, interp_error) if interp_profile is not None else None
-
-    if interp_quality is not RBAQualityFlag.OK:
-        return _PixelCoreResult(quality=interp_quality, peak_velocity=peak_velocity), detail
-
-    red_intensity, blue_intensity, peak, quality = _compute_wings_and_peak(
-        interp_profile, ctx.red_mask, ctx.blue_mask, ctx.min_wing_coverage
-    )
-    if quality is not RBAQualityFlag.OK:
-        return _PixelCoreResult(quality=quality, peak_velocity=peak_velocity), detail
-
-    rba = (red_intensity - blue_intensity) / peak
-    rba_error, red_err, blue_err = _propagate_rba_error(
-        red_intensity, blue_intensity, peak, interp_error, ctx.red_mask, ctx.blue_mask, interp_profile
-    )
-
-    core = _PixelCoreResult(
-        quality=RBAQualityFlag.OK,
-        rba=rba,
-        red_wing=red_intensity,
-        blue_wing=blue_intensity,
-        peak_intensity=peak,
-        peak_velocity=peak_velocity,
-        red_blue_error=rba_error,
-        red_wing_error=red_err,
-        blue_wing_error=blue_err,
-    )
-    return core, detail
 
 
 def calculate_red_blue_asymmetry(
@@ -348,8 +184,7 @@ def calculate_red_blue_asymmetry(
     `irispy.spectrograph.RasterCollection`
     """
     if rest_wavelength is None:
-        with contextlib.suppress(AttributeError):
-            rest_wavelength = cube.meta.rest_wavelength
+        rest_wavelength = getattr(cube.meta, "rest_wavelength", None)
         if rest_wavelength is None:
             msg = (
                 "rest_wavelength was not provided and could not be read from cube.meta. "
@@ -399,23 +234,8 @@ def calculate_red_blue_asymmetry(
     red_mask = (interp_velocity >= low) & (interp_velocity <= high)
     blue_mask = (interp_velocity >= -high) & (interp_velocity <= -low)
 
-    ctx = _RBAContext(
-        velocity=velocity,
-        interp_velocity=interp_velocity,
-        degree=degree,
-        red_mask=red_mask,
-        blue_mask=blue_mask,
-        min_wing_coverage=0.8,
-    )
-
     red_blue = np.full(output_shape, np.nan)
     red_blue_error = np.full(output_shape, np.nan)
-    red_wing = np.full(output_shape, np.nan)
-    blue_wing = np.full(output_shape, np.nan)
-    red_wing_error = np.full(output_shape, np.nan)
-    blue_wing_error = np.full(output_shape, np.nan)
-    peak_intensity = np.full(output_shape, np.nan)
-    peak_velocity = np.full(output_shape, np.nan)
     quality = np.full(output_shape, RBAQualityFlag.OK, dtype=np.uint8)
 
     with warnings.catch_warnings():
@@ -441,25 +261,92 @@ def calculate_red_blue_asymmetry(
         else None
     )
 
+    min_points = degree + 1
+    min_wing_coverage = 0.8
     for index in np.ndindex(output_shape):
         if quality[index] in (RBAQualityFlag.LOW_SIGNAL, RBAQualityFlag.SATURATED):
             continue
 
-        core, detail = _process_pixel(data[index], None if errors is None else errors[index], ctx)
+        profile = data[index]
+        profile_error = None if errors is None else errors[index]
+        finite_profile = np.isfinite(profile)
+        if not finite_profile.any():
+            quality[index] = RBAQualityFlag.NO_FINITE_DATA
+            continue
 
-        red_blue[index] = core.rba
-        red_wing[index] = core.red_wing
-        blue_wing[index] = core.blue_wing
-        peak_intensity[index] = core.peak_intensity
-        peak_velocity[index] = core.peak_velocity
-        quality[index] = core.quality
-        red_blue_error[index] = core.red_blue_error
-        red_wing_error[index] = core.red_wing_error
-        blue_wing_error[index] = core.blue_wing_error
-        if return_profiles and detail is not None:
-            interpolated_profiles[index] = detail.interp_profile
-            if interpolated_errors is not None and detail.interp_error is not None:
-                interpolated_errors[index] = detail.interp_error
+        peak_index = np.nanargmax(np.where(finite_profile, profile, np.nan))
+        if peak_index == 0 or peak_index == profile.size - 1:
+            quality[index] = RBAQualityFlag.PEAK_AT_EDGE
+            continue
+
+        shifted_velocity = velocity - velocity[peak_index]
+        finite = np.isfinite(shifted_velocity) & finite_profile
+        if finite.sum() < min_points:
+            quality[index] = RBAQualityFlag.TOO_FEW_POINTS
+            continue
+
+        order = np.argsort(shifted_velocity[finite])
+        ordered_velocity = shifted_velocity[finite][order]
+        ordered_profile = profile[finite][order]
+        try:
+            interp_profile = make_interp_spline(ordered_velocity, ordered_profile, k=degree)(
+                interp_velocity, extrapolate=False
+            )
+        except ValueError:
+            quality[index] = RBAQualityFlag.INTERP_FAILED
+            continue
+
+        interp_error = None
+        if profile_error is not None:
+            ordered_error = profile_error[finite][order]
+            finite_error = np.isfinite(ordered_error)
+            if finite_error.sum() >= min_points:
+                try:
+                    interp_error = make_interp_spline(
+                        ordered_velocity[finite_error], ordered_error[finite_error], k=degree
+                    )(interp_velocity, extrapolate=False)
+                except ValueError:
+                    quality[index] = RBAQualityFlag.INTERP_FAILED
+                    continue
+                interp_error = np.where(interp_error >= 0, interp_error, np.nan)
+
+        if return_profiles:
+            interpolated_profiles[index] = interp_profile
+            if interpolated_errors is not None and interp_error is not None:
+                interpolated_errors[index] = interp_error
+
+        red_finite = red_mask & np.isfinite(interp_profile)
+        blue_finite = blue_mask & np.isfinite(interp_profile)
+        if red_finite.sum() < min_wing_coverage * red_mask.sum():
+            quality[index] = RBAQualityFlag.INCOMPLETE_WINGS
+            continue
+        if blue_finite.sum() < min_wing_coverage * blue_mask.sum():
+            quality[index] = RBAQualityFlag.INCOMPLETE_WINGS
+            continue
+
+        red_intensity = np.nanmean(interp_profile[red_finite]) if red_finite.any() else np.nan
+        blue_intensity = np.nanmean(interp_profile[blue_finite]) if blue_finite.any() else np.nan
+        peak = np.nanmax(interp_profile)
+        if not np.isfinite(peak) or np.isclose(peak, 0):
+            quality[index] = RBAQualityFlag.PEAK_IS_ZERO
+            continue
+
+        numerator = red_intensity - blue_intensity
+        red_blue[index] = numerator / peak
+
+        if interp_error is not None:
+            n_red = np.isfinite(interp_error[red_mask]).sum()
+            n_blue = np.isfinite(interp_error[blue_mask]).sum()
+            red_err = np.sqrt(np.nansum(interp_error[red_mask] ** 2)) / n_red if n_red > 0 else np.nan
+            blue_err = np.sqrt(np.nansum(interp_error[blue_mask] ** 2)) / n_blue if n_blue > 0 else np.nan
+            peak_err = interp_error[np.nanargmax(interp_profile)]
+            num_err = np.sqrt(red_err**2 + blue_err**2)
+            numerator_is_zero = np.isclose(numerator, 0)
+            if np.isfinite(num_err) and (numerator_is_zero or np.isfinite(peak_err)):
+                variance = (num_err / peak) ** 2
+                if not numerator_is_zero:
+                    variance += (numerator * peak_err / peak**2) ** 2
+                red_blue_error[index] = np.sqrt(variance)
 
     meta = {
         "rba_rest_wavelength": rest_wavelength.to_value(u.nm),
@@ -480,20 +367,10 @@ def calculate_red_blue_asymmetry(
 
     cubes = [
         ("red_blue_asymmetry", red_blue, u.dimensionless_unscaled),
-        ("red_wing", red_wing, cube.unit),
-        ("blue_wing", blue_wing, cube.unit),
-        ("peak_intensity", peak_intensity, cube.unit),
-        ("peak_velocity", peak_velocity, u.km / u.s),
         ("quality", quality, u.dimensionless_unscaled),
     ]
     if errors is not None:
-        cubes.extend(
-            [
-                ("red_blue_asymmetry_error", red_blue_error, u.dimensionless_unscaled),
-                ("red_wing_error", red_wing_error, cube.unit),
-                ("blue_wing_error", blue_wing_error, cube.unit),
-            ]
-        )
+        cubes.append(("red_blue_asymmetry_error", red_blue_error, u.dimensionless_unscaled))
 
     result_cubes = []
     for name, values, unit in cubes:

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -4,6 +4,7 @@ Red-blue asymmetry utilities for IRIS spectrogram cubes.
 
 import warnings
 from enum import IntEnum
+from dataclasses import dataclass
 
 import numpy as np
 from scipy.interpolate import make_interp_spline
@@ -19,8 +20,6 @@ from irispy.spectrograph import RasterCollection, SpectrogramCube
 from irispy.utils._spectral import drop_extra_coords_dependent_on_axis, make_map_cube, make_spatial_template
 
 __all__ = ["RBAQualityFlag", "calculate_red_blue_asymmetry"]
-
-_INTERPOLATION_DEGREES = {"linear": 1, "quadratic": 2, "cubic": 3}
 
 
 class RBAQualityFlag(IntEnum):
@@ -80,16 +79,7 @@ def _make_velocity_wcs(base_wcs, array_shape, velocity_axis, velocity_grid):
     return WCS(header)
 
 
-def _make_profile_cube(
-    cube,
-    *,
-    data,
-    velocity_grid,
-    wavelength_axis,
-    meta,
-    uncertainty=None,
-    mask=None,
-):
+def _make_profile_cube(cube, *, data, velocity_grid, wavelength_axis, meta, uncertainty=None, mask=None):
     return SpectrogramCube(
         data,
         wcs=_make_velocity_wcs(cube.wcs, data.shape, wavelength_axis, velocity_grid),
@@ -101,10 +91,240 @@ def _make_profile_cube(
     )
 
 
+@dataclass
+class _PixelCoreResult:
+    quality: RBAQualityFlag
+    rba: float = np.nan
+    red_wing: float = np.nan
+    blue_wing: float = np.nan
+    peak_intensity: float = np.nan
+    peak_velocity: float = np.nan
+    red_blue_error: float = np.nan
+    red_wing_error: float = np.nan
+    blue_wing_error: float = np.nan
+
+
+@dataclass
+class _PixelProfileDetail:
+    interp_profile: np.ndarray
+    interp_error: np.ndarray | None = None
+
+
+@dataclass
+class _RBAContext:
+    velocity: np.ndarray
+    interp_velocity: np.ndarray
+    center_on_peak: bool
+    fit_window: float
+    d_velocity: float
+    degree: int
+    red_mask: np.ndarray
+    blue_mask: np.ndarray
+    min_wing_coverage: float
+
+
+def _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows, uncertainty):
+    """
+    Extract data/errors, mask negatives, subtract continuum, move spectral axis to -1.
+    """
+    data = np.asarray(cube.data, dtype=float)
+    if cube.mask is not None:
+        data = np.where(cube.mask, np.nan, data)
+    data = np.where(data < 0, np.nan, data)
+
+    if uncertainty is not None:
+        errors = u.Quantity(uncertainty, cube.unit).to_value(cube.unit)
+    elif cube.uncertainty is not None:
+        errors = np.asarray(cube.uncertainty.array, dtype=float)
+    else:
+        errors = None
+    if errors is not None and cube.mask is not None:
+        errors = np.where(cube.mask, np.nan, errors)
+
+    data = np.moveaxis(data, wavelength_axis, -1)
+    if errors is not None:
+        errors = np.moveaxis(errors, wavelength_axis, -1)
+
+    if continuum_windows is not None:
+        windows = u.Quantity(continuum_windows).to(wavelengths.unit)
+        if windows.shape == (2,):
+            windows = windows[np.newaxis, :]
+        if windows.ndim != 2 or windows.shape[1] != 2:
+            msg = "continuum_windows must have shape (2,) or (n, 2)"
+            raise ValueError(msg)
+        continuum_mask = np.zeros(wavelengths.shape, dtype=bool)
+        for low, high in windows:
+            continuum_mask |= (wavelengths >= low) & (wavelengths <= high)
+        if not continuum_mask.any():
+            msg = "No wavelength points found within continuum_windows"
+            raise ValueError(msg)
+        continuum_values = np.nanmean(data[..., continuum_mask], axis=-1)
+        data = data - continuum_values[..., np.newaxis]
+        if errors is not None:
+            n_finite = np.isfinite(errors[..., continuum_mask]).sum(axis=-1)
+            continuum_errors = np.sqrt(np.nansum(errors[..., continuum_mask] ** 2, axis=-1))
+            continuum_errors = np.where(n_finite > 0, continuum_errors / n_finite, np.nan)
+            errors = np.sqrt(errors**2 + continuum_errors[..., np.newaxis] ** 2)
+
+    return data, errors
+
+
+def _window_profile(profile, profile_error, velocity, peak_index, *, center_on_peak, fit_window, d_velocity):
+    if center_on_peak:
+        if peak_index == 0 or peak_index == profile.size - 1:
+            return None, None, None, RBAQualityFlag.PEAK_AT_EDGE
+        window_pixels = profile.size if d_velocity == 0 else int(fit_window / abs(d_velocity))
+        low_idx = max(0, peak_index - window_pixels)
+        high_idx = min(profile.size, peak_index + window_pixels)
+        fit_slice = slice(low_idx, high_idx)
+        shifted_velocity = velocity[fit_slice] - velocity[peak_index]
+        profile = profile[fit_slice]
+        if profile_error is not None:
+            profile_error = profile_error[fit_slice]
+    else:
+        fit_mask = np.abs(velocity) <= fit_window
+        shifted_velocity = velocity[fit_mask]
+        profile = profile[fit_mask]
+        if profile_error is not None:
+            profile_error = profile_error[fit_mask]
+
+    return shifted_velocity, profile, profile_error, RBAQualityFlag.OK
+
+
+def _interpolate_profile_and_error(shifted_velocity, profile, profile_error, interp_velocity, degree):
+    finite = np.isfinite(shifted_velocity) & np.isfinite(profile)
+    min_points = degree + 1
+    if finite.sum() < min_points:
+        return None, None, RBAQualityFlag.TOO_FEW_POINTS
+
+    sv, sp = shifted_velocity[finite], profile[finite]
+    order = np.argsort(sv)
+    ordered_velocity, ordered_profile = sv[order], sp[order]
+
+    try:
+        interp_profile = make_interp_spline(ordered_velocity, ordered_profile, k=degree)(
+            interp_velocity, extrapolate=False
+        )
+    except ValueError:
+        return None, None, RBAQualityFlag.INTERP_FAILED
+
+    interp_error = None
+    if profile_error is not None:
+        ordered_error = profile_error[finite][order]
+        finite_error = np.isfinite(ordered_error)
+        if finite_error.sum() >= min_points:
+            try:
+                interp_error = make_interp_spline(
+                    ordered_velocity[finite_error], ordered_error[finite_error], k=degree
+                )(interp_velocity, extrapolate=False)
+                interp_error = np.where(interp_error >= 0, interp_error, np.nan)
+            except ValueError:
+                return None, None, RBAQualityFlag.INTERP_FAILED
+
+    return interp_profile, interp_error, RBAQualityFlag.OK
+
+
+def _compute_wings_and_peak(interp_profile, red_mask, blue_mask, min_wing_coverage):
+    red_finite = red_mask & np.isfinite(interp_profile)
+    blue_finite = blue_mask & np.isfinite(interp_profile)
+    if red_finite.sum() < min_wing_coverage * red_mask.sum() or blue_finite.sum() < min_wing_coverage * blue_mask.sum():
+        return np.nan, np.nan, np.nan, RBAQualityFlag.INCOMPLETE_WINGS
+
+    red_intensity = np.nanmean(interp_profile[red_finite]) if red_finite.any() else np.nan
+    blue_intensity = np.nanmean(interp_profile[blue_finite]) if blue_finite.any() else np.nan
+    peak = np.nanmax(interp_profile)
+    if not np.isfinite(peak) or np.isclose(peak, 0):
+        return np.nan, np.nan, np.nan, RBAQualityFlag.PEAK_IS_ZERO
+
+    return red_intensity, blue_intensity, peak, RBAQualityFlag.OK
+
+
+def _propagate_rba_error(red_intensity, blue_intensity, peak, interp_error, red_mask, blue_mask, interp_profile):
+    """Propagate uncertainties through ``(I_R - I_B) / I_p``."""
+    if interp_error is None:
+        return np.nan, np.nan, np.nan
+
+    n_red = np.isfinite(interp_error[red_mask]).sum()
+    n_blue = np.isfinite(interp_error[blue_mask]).sum()
+    red_err = np.sqrt(np.nansum(interp_error[red_mask] ** 2)) / n_red if n_red > 0 else np.nan
+    blue_err = np.sqrt(np.nansum(interp_error[blue_mask] ** 2)) / n_blue if n_blue > 0 else np.nan
+    peak_err = interp_error[np.nanargmax(interp_profile)]
+    numerator = red_intensity - blue_intensity
+    num_err = np.sqrt(red_err**2 + blue_err**2)
+
+    rba_error = np.nan
+    numerator_is_zero = np.isclose(numerator, 0)
+    if np.isfinite(num_err) and (numerator_is_zero or np.isfinite(peak_err)):
+        variance = (num_err / peak) ** 2
+        if not numerator_is_zero:
+            variance += (numerator * peak_err / peak**2) ** 2
+        rba_error = np.sqrt(variance)
+
+    return rba_error, red_err, blue_err
+
+
+def _process_pixel(profile, profile_error, ctx: _RBAContext):
+    """
+    Compute RBA for a single spatial pixel.
+
+    Returns (``_PixelCoreResult``, ``_PixelProfileDetail | None``).
+    """
+    finite_profile = np.isfinite(profile)
+    if not finite_profile.any():
+        return _PixelCoreResult(quality=RBAQualityFlag.NO_FINITE_DATA), None
+
+    peak_index = np.nanargmax(np.where(finite_profile, profile, np.nan))
+    peak_velocity = ctx.velocity[peak_index]
+
+    shifted_velocity, profile, profile_error, quality = _window_profile(
+        profile,
+        profile_error,
+        ctx.velocity,
+        peak_index,
+        center_on_peak=ctx.center_on_peak,
+        fit_window=ctx.fit_window,
+        d_velocity=ctx.d_velocity,
+    )
+    if quality is not RBAQualityFlag.OK:
+        return _PixelCoreResult(quality=quality, peak_velocity=peak_velocity), None
+
+    interp_profile, interp_error, interp_quality = _interpolate_profile_and_error(
+        shifted_velocity, profile, profile_error, ctx.interp_velocity, ctx.degree
+    )
+    detail = _PixelProfileDetail(interp_profile, interp_error) if interp_profile is not None else None
+
+    if interp_quality is not RBAQualityFlag.OK:
+        return _PixelCoreResult(quality=interp_quality, peak_velocity=peak_velocity), detail
+
+    red_intensity, blue_intensity, peak, quality = _compute_wings_and_peak(
+        interp_profile, ctx.red_mask, ctx.blue_mask, ctx.min_wing_coverage
+    )
+    if quality is not RBAQualityFlag.OK:
+        return _PixelCoreResult(quality=quality, peak_velocity=peak_velocity), detail
+
+    rba = (red_intensity - blue_intensity) / peak
+    rba_error, red_err, blue_err = _propagate_rba_error(
+        red_intensity, blue_intensity, peak, interp_error, ctx.red_mask, ctx.blue_mask, interp_profile
+    )
+
+    core = _PixelCoreResult(
+        quality=RBAQualityFlag.OK,
+        rba=rba,
+        red_wing=red_intensity,
+        blue_wing=blue_intensity,
+        peak_intensity=peak,
+        peak_velocity=peak_velocity,
+        red_blue_error=rba_error,
+        red_wing_error=red_err,
+        blue_wing_error=blue_err,
+    )
+    return core, detail
+
+
 def calculate_red_blue_asymmetry(
     cube,
     *,
-    rest_wavelength,
+    rest_wavelength=None,
     velocity_range=(50, 150) * u.km / u.s,
     velocity_window=None,
     fit_window=None,
@@ -112,8 +332,7 @@ def calculate_red_blue_asymmetry(
     center_on_peak=True,
     continuum_windows=None,
     uncertainty=None,
-    interpolation_kind="cubic",
-    mask_negative=True,
+    degree=3,
     min_intensity=None,
     saturation_limit=None,
     return_profiles=True,
@@ -130,8 +349,10 @@ def calculate_red_blue_asymmetry(
     ----------
     cube : `irispy.spectrograph.SpectrogramCube`
         Input spectrogram cube.
-    rest_wavelength : `astropy.units.Quantity`
+    rest_wavelength : `astropy.units.Quantity`, optional
         Rest wavelength used to convert the spectral axis to Doppler velocity.
+        If omitted, read from ``cube.meta.rest_wavelength`` (requires an
+        `~irispy.meta.SGMeta` instance with a ``TWAVE<n>`` FITS keyword).
     velocity_range : `astropy.units.Quantity`, optional
         Two positive velocities defining the wing range to average.
     velocity_window : `astropy.units.Quantity`, optional
@@ -152,35 +373,34 @@ def calculate_red_blue_asymmetry(
     uncertainty : `astropy.units.Quantity`, optional
         Per-bin intensity uncertainty. If omitted, ``cube.uncertainty`` is
         used when available.
-    interpolation_kind : {"linear", "quadratic", "cubic"} or `int`, optional
-        Spline degree used by `scipy.interpolate.make_interp_spline`.
-    mask_negative : `bool`, optional
-        If `True`, negative intensities are set to NaN before computing
-        moments.
+    degree : `int`, optional
+        Spline degree for `scipy.interpolate.make_interp_spline`.
     min_intensity : `float` or `astropy.units.Quantity`, optional
         Minimum peak intensity required for a pixel to be processed.
-        Pixels with a peak below this threshold are skipped and assigned
-        quality flag `~irispy.utils.red_blue.RBAQualityFlag.LOW_SIGNAL`.
+        Pixels below this threshold are assigned quality flag
+        `~irispy.utils.red_blue.RBAQualityFlag.LOW_SIGNAL`.
     saturation_limit : `float` or `astropy.units.Quantity`, optional
-        Maximum allowed peak intensity. Pixels where the peak exceeds this
-        value are treated as saturated, skipped, and assigned quality flag
-        `~irispy.utils.red_blue.RBAQualityFlag.SATURATED`.
+        Maximum allowed peak intensity. Pixels above this value are assigned
+        quality flag `~irispy.utils.red_blue.RBAQualityFlag.SATURATED`.
     return_profiles : `bool`, optional
-        If `True`, include plot-ready 3D ``"observed_profile"`` and
-        ``"interpolated_profile"`` cubes in the output. Set to `False` to
-        reduce peak memory use when only the 2D maps are needed.
+        If `True`, include 3D ``"observed_profile"`` and
+        ``"interpolated_profile"`` cubes in the output.
 
     Returns
     -------
     `irispy.spectrograph.RasterCollection`
-        Collection with 2D maps. When ``return_profiles=True``, the collection
-        also includes plot-ready 3D ``"observed_profile"`` and
-        ``"interpolated_profile"`` `~irispy.spectrograph.SpectrogramCube`
-        instances. The ``"quality"`` cube stores per-pixel integer flags
-        described by
-        `irispy.utils.red_blue.RBAQualityFlag`.
     """
-    # -- Validate velocity_range ------------------------------------------------
+    if rest_wavelength is None:
+        try:
+            rest_wavelength = cube.meta.rest_wavelength
+        except (AttributeError, TypeError) as exc:
+            msg = (
+                "rest_wavelength was not provided and could not be read from cube.meta. "
+                "Pass rest_wavelength explicitly or provide a cube with SGMeta containing TWAVE keywords."
+            )
+            raise ValueError(msg) from exc
+    rest_wavelength = u.Quantity(rest_wavelength).to(u.nm)
+
     velocity_range = u.Quantity(velocity_range).to(u.km / u.s)
     if velocity_range.shape != (2,):
         msg = "velocity_range must contain two velocities"
@@ -190,13 +410,15 @@ def calculate_red_blue_asymmetry(
         msg = "velocity_range must be positive and increasing"
         raise ValueError(msg)
 
-    velocity_window = velocity_high + 50 * u.km / u.s if velocity_window is None else u.Quantity(velocity_window)
-    velocity_window = velocity_window.to_value(u.km / u.s)
-    fit_window = velocity_high + 100 * u.km / u.s if fit_window is None else u.Quantity(fit_window)
-    fit_window = fit_window.to_value(u.km / u.s)
+    velocity_window = (
+        velocity_high + 50 * u.km / u.s if velocity_window is None else u.Quantity(velocity_window)
+    ).to_value(u.km / u.s)
+    fit_window = (velocity_high + 100 * u.km / u.s if fit_window is None else u.Quantity(fit_window)).to_value(
+        u.km / u.s
+    )
     dv = u.Quantity(dv).to_value(u.km / u.s)
     if velocity_window <= velocity_high.to_value(u.km / u.s):
-        msg = "velocity_window must be larger than the high end of velocity_range"
+        msg = "velocity_window must be larger than velocity_range high end"
         raise ValueError(msg)
     if fit_window <= velocity_window:
         msg = "fit_window must be larger than velocity_window"
@@ -204,79 +426,43 @@ def calculate_red_blue_asymmetry(
     if dv <= 0:
         msg = "dv must be positive"
         raise ValueError(msg)
-    interpolation_degree = _INTERPOLATION_DEGREES.get(interpolation_kind, interpolation_kind)
-    try:
-        interpolation_degree = int(interpolation_degree)
-    except (TypeError, ValueError) as exc:
-        msg = "interpolation_kind must be 'linear', 'quadratic', 'cubic', or an integer spline degree"
-        raise ValueError(msg) from exc
-    if interpolation_degree < 0:
-        msg = "interpolation_kind must be a non-negative spline degree"
+    degree = int(degree)
+    if degree < 0:
+        msg = "degree must be a non-negative integer"
         raise ValueError(msg)
 
-    # -- Locate spectral axis and compute velocities ----------------------------
     try:
-        wavelength_axis = next(
-            axis
-            for axis, physical_types in enumerate(cube.array_axis_physical_types)
-            if physical_types and "em.wl" in physical_types
-        )
-    except StopIteration as exc:
+        wavelength_axis = cube.wavelength_axis
+    except (AttributeError, StopIteration) as exc:
         msg = "Could not identify a spectral wavelength axis on the input cube"
         raise ValueError(msg) from exc
     wavelengths = cube.axis_world_coords(wavelength_axis)[0].to(u.nm)
-    rest_wavelength = u.Quantity(rest_wavelength).to(wavelengths.unit)
+    rest_wavelength = rest_wavelength.to(wavelengths.unit)
     velocity = ((wavelengths - rest_wavelength) / rest_wavelength * constants.c).to_value(u.km / u.s)
     interp_velocity = np.arange(-velocity_window, velocity_window + dv, dv)
-    velocity_range_value = (velocity_low.to_value(u.km / u.s), velocity_high.to_value(u.km / u.s))
+    velocity_range_kms = (velocity_low.to_value(u.km / u.s), velocity_high.to_value(u.km / u.s))
 
-    # -- Prepare data and uncertainty -------------------------------------------
-    data = np.asarray(cube.data, dtype=float)
-    if cube.mask is not None:
-        data = np.where(cube.mask, np.nan, data)
-    if mask_negative:
-        data = np.where(data < 0, np.nan, data)
+    data, errors = _prepare_data(cube, wavelengths, wavelength_axis, continuum_windows, uncertainty)
 
-    if uncertainty is not None:
-        errors = u.Quantity(uncertainty, cube.unit).to_value(cube.unit)
-    elif cube.uncertainty is not None:
-        errors = np.asarray(cube.uncertainty.array, dtype=float)
-    else:
-        errors = None
-    if errors is not None and cube.mask is not None:
-        errors = np.where(cube.mask, np.nan, errors)
-
-    # -- Continuum subtraction --------------------------------------------------
-    if continuum_windows is not None:
-        windows = u.Quantity(continuum_windows).to(wavelengths.unit)
-        if windows.shape == (2,):
-            windows = windows[np.newaxis, :]
-        if windows.ndim != 2 or windows.shape[1] != 2:
-            msg = "continuum_windows must have shape (2,) or (n, 2)"
-            raise ValueError(msg)
-        continuum = np.zeros(wavelengths.shape, dtype=bool)
-        for low, high in windows:
-            continuum |= (wavelengths >= low) & (wavelengths <= high)
-        if not continuum.any():
-            msg = "No wavelength points found within continuum_windows"
-            raise ValueError(msg)
-        data = np.moveaxis(data, wavelength_axis, -1)
-        if errors is not None:
-            errors = np.moveaxis(errors, wavelength_axis, -1)
-        continuum_values = np.nanmean(data[..., continuum], axis=-1)
-        data = data - continuum_values[..., np.newaxis]
-        if errors is not None:
-            n_finite = np.isfinite(errors[..., continuum]).sum(axis=-1)
-            continuum_errors = np.sqrt(np.nansum(errors[..., continuum] ** 2, axis=-1))
-            continuum_errors = np.where(n_finite > 0, continuum_errors / n_finite, np.nan)
-            errors = np.sqrt(errors**2 + continuum_errors[..., np.newaxis] ** 2)
-    else:
-        data = np.moveaxis(data, wavelength_axis, -1)
-        if errors is not None:
-            errors = np.moveaxis(errors, wavelength_axis, -1)
-
-    # -- Per-pixel red-blue computation -----------------------------------------
     output_shape = data.shape[:-1]
+    d_velocity = float(np.nanmean(np.diff(velocity))) if velocity.size > 1 else 1.0
+
+    low, high = velocity_range_kms
+    red_mask = (interp_velocity >= low) & (interp_velocity <= high)
+    blue_mask = (interp_velocity >= -high) & (interp_velocity <= -low)
+
+    ctx = _RBAContext(
+        velocity=velocity,
+        interp_velocity=interp_velocity,
+        center_on_peak=center_on_peak,
+        fit_window=fit_window,
+        d_velocity=d_velocity,
+        degree=degree,
+        red_mask=red_mask,
+        blue_mask=blue_mask,
+        min_wing_coverage=0.8,
+    )
+
     red_blue = np.full(output_shape, np.nan)
     red_blue_error = np.full(output_shape, np.nan)
     red_wing = np.full(output_shape, np.nan)
@@ -287,24 +473,19 @@ def calculate_red_blue_asymmetry(
     peak_velocity = np.full(output_shape, np.nan)
     quality = np.full(output_shape, RBAQualityFlag.OK, dtype=np.uint8)
 
-    # Apply min_intensity and saturation_limit masks before the loop
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)
         raw_peak = np.nanmax(data, axis=-1)
     if min_intensity is not None:
-        if isinstance(min_intensity, u.Quantity):
-            min_intensity_value = min_intensity.to_value(cube.unit)
-        else:
-            min_intensity_value = min_intensity
-        low_signal = raw_peak < min_intensity_value
-        quality = np.where(low_signal, RBAQualityFlag.LOW_SIGNAL, quality)
+        min_intensity_value = (
+            min_intensity.to_value(cube.unit) if isinstance(min_intensity, u.Quantity) else min_intensity
+        )
+        quality = np.where(raw_peak < min_intensity_value, RBAQualityFlag.LOW_SIGNAL, quality)
     if saturation_limit is not None:
-        if isinstance(saturation_limit, u.Quantity):
-            saturation_limit_value = saturation_limit.to_value(cube.unit)
-        else:
-            saturation_limit_value = saturation_limit
-        saturated = raw_peak > saturation_limit_value
-        quality = np.where(saturated, RBAQualityFlag.SATURATED, quality)
+        saturation_limit_value = (
+            saturation_limit.to_value(cube.unit) if isinstance(saturation_limit, u.Quantity) else saturation_limit
+        )
+        quality = np.where(raw_peak > saturation_limit_value, RBAQualityFlag.SATURATED, quality)
 
     interpolated_profiles = (
         np.full((*output_shape, interp_velocity.size), np.nan, dtype=float) if return_profiles else None
@@ -315,176 +496,83 @@ def calculate_red_blue_asymmetry(
         else None
     )
 
-    low, high = velocity_range_value
-    red_mask = (interp_velocity >= low) & (interp_velocity <= high)
-    blue_mask = (interp_velocity >= -high) & (interp_velocity <= -low)
-
     for index in np.ndindex(output_shape):
         if quality[index] in (RBAQualityFlag.LOW_SIGNAL, RBAQualityFlag.SATURATED):
             continue
-        profile = data[index]
-        profile_error = None if errors is None else errors[index]
-        finite_profile = np.isfinite(profile)
-        if not finite_profile.any():
-            quality[index] = RBAQualityFlag.NO_FINITE_DATA
-            continue
-        peak_index = np.nanargmax(np.where(finite_profile, profile, np.nan))
-        peak_velocity[index] = velocity[peak_index]
 
-        if center_on_peak:
-            # Reject only if the peak itself sits at the very edge of the array
-            if peak_index == 0 or peak_index == profile.size - 1:
-                quality[index] = RBAQualityFlag.PEAK_AT_EDGE
-                continue
-            d_velocity = np.nanmean(np.diff(velocity))
-            window_pixels = int(fit_window / abs(d_velocity))
-            # Clamp the slice to available data (old prototype behaviour)
-            low_idx = max(0, peak_index - window_pixels)
-            high_idx = min(profile.size, peak_index + window_pixels)
-            sl = slice(low_idx, high_idx)
-            shifted_velocity = velocity[sl] - velocity[peak_index]
-            profile = profile[sl]
-            if profile_error is not None:
-                profile_error = profile_error[sl]
-        else:
-            fit_mask = np.abs(velocity) <= fit_window
-            shifted_velocity = velocity[fit_mask]
-            profile = profile[fit_mask]
-            if profile_error is not None:
-                profile_error = profile_error[fit_mask]
+        core, detail = _process_pixel(data[index], None if errors is None else errors[index], ctx)
 
-        # Interpolate onto uniform velocity grid
-        finite = np.isfinite(shifted_velocity) & np.isfinite(profile)
-        min_points = interpolation_degree + 1
-        if finite.sum() < min_points:
-            quality[index] = RBAQualityFlag.TOO_FEW_POINTS
-            continue
-        sv = shifted_velocity[finite]
-        sp = profile[finite]
-        order = np.argsort(sv)
-        ordered_velocity = sv[order]
-        ordered_profile = sp[order]
-        try:
-            interp_profile = make_interp_spline(ordered_velocity, ordered_profile, k=interpolation_degree)(
-                interp_velocity,
-                extrapolate=False,
-            )
-        except ValueError:
-            quality[index] = RBAQualityFlag.INTERP_FAILED
-            continue
-        if profile_error is not None:
-            ordered_error = profile_error[finite][order]
-            finite_error = np.isfinite(ordered_error)
-            if finite_error.sum() >= min_points:
-                try:
-                    interp_error = make_interp_spline(
-                        ordered_velocity[finite_error],
-                        ordered_error[finite_error],
-                        k=interpolation_degree,
-                    )(interp_velocity, extrapolate=False)
-                    interp_error = np.where(interp_error >= 0, interp_error, np.nan)
-                except ValueError:
-                    quality[index] = RBAQualityFlag.INTERP_FAILED
-                    continue
-            else:
-                interp_error = None
-        else:
-            interp_error = None
+        red_blue[index] = core.rba
+        red_wing[index] = core.red_wing
+        blue_wing[index] = core.blue_wing
+        peak_intensity[index] = core.peak_intensity
+        peak_velocity[index] = core.peak_velocity
+        quality[index] = core.quality
+        red_blue_error[index] = core.red_blue_error
+        red_wing_error[index] = core.red_wing_error
+        blue_wing_error[index] = core.blue_wing_error
+        if return_profiles and detail is not None:
+            interpolated_profiles[index] = detail.interp_profile
+            if interpolated_errors is not None and detail.interp_error is not None:
+                interpolated_errors[index] = detail.interp_error
 
-        if return_profiles:
-            interpolated_profiles[index] = interp_profile
-        if interp_error is not None and return_profiles:
-            interpolated_errors[index] = interp_error
-
-        red_finite = red_mask & np.isfinite(interp_profile)
-        blue_finite = blue_mask & np.isfinite(interp_profile)
-        if red_finite.sum() < 0.8 * red_mask.sum() or blue_finite.sum() < 0.8 * blue_mask.sum():
-            quality[index] = RBAQualityFlag.INCOMPLETE_WINGS
-            continue
-        red_intensity = np.nanmean(interp_profile[red_finite]) if red_finite.any() else np.nan
-        blue_intensity = np.nanmean(interp_profile[blue_finite]) if blue_finite.any() else np.nan
-        peak = np.nanmax(interp_profile)
-        if not np.isfinite(peak) or peak == 0:
-            quality[index] = RBAQualityFlag.PEAK_IS_ZERO
-            continue
-        rba = (red_intensity - blue_intensity) / peak
-        red_blue[index] = rba
-        red_wing[index] = red_intensity
-        blue_wing[index] = blue_intensity
-        peak_intensity[index] = peak
-
-        if interp_error is not None and np.isfinite(rba):
-            n_red = np.isfinite(interp_error[red_mask]).sum()
-            n_blue = np.isfinite(interp_error[blue_mask]).sum()
-            red_err = np.sqrt(np.nansum(interp_error[red_mask] ** 2)) / n_red if n_red > 0 else np.nan
-            blue_err = np.sqrt(np.nansum(interp_error[blue_mask] ** 2)) / n_blue if n_blue > 0 else np.nan
-            peak_err = interp_error[np.nanargmax(interp_profile)]
-            numerator = red_intensity - blue_intensity
-            num_err = np.sqrt(red_err**2 + blue_err**2)
-            if np.isfinite(num_err) and (numerator == 0 or np.isfinite(peak_err)):
-                variance = (num_err / peak) ** 2
-                if numerator != 0:
-                    variance += (numerator * peak_err / peak**2) ** 2
-                red_blue_error[index] = np.sqrt(variance)
-            red_wing_error[index] = red_err
-            blue_wing_error[index] = blue_err
-
-    # -- Build meta with computation parameters ---------------------------------
     meta = {
         "rba_rest_wavelength": rest_wavelength.to_value(u.nm),
         "rba_rest_wavelength_unit": "nm",
-        "rba_velocity_range": velocity_range_value,
+        "rba_velocity_range": velocity_range_kms,
         "rba_velocity_window": velocity_window,
         "rba_fit_window": fit_window,
         "rba_dv": dv,
         "rba_center_on_peak": center_on_peak,
-        "rba_interpolation_kind": interpolation_kind,
-        "rba_mask_negative": mask_negative,
+        "rba_interpolation_degree": degree,
     }
     if continuum_windows is not None:
         meta["rba_continuum_windows"] = str(continuum_windows)
+
+    template = make_spatial_template(cube, wavelength_axis)
 
     def _make_cube(values, unit, *, mask=None):
         c = make_map_cube(template, values, unit, mask=mask)
         c.meta.update(meta)
         return c
 
-    # -- Build output RasterCollection ------------------------------------------
-    template = make_spatial_template(cube, wavelength_axis)
     cubes = [
-        ("red_blue_asymmetry", _make_cube(red_blue, u.dimensionless_unscaled, mask=~np.isfinite(red_blue))),
-        ("red_wing", _make_cube(red_wing, cube.unit, mask=~np.isfinite(red_wing))),
-        ("blue_wing", _make_cube(blue_wing, cube.unit, mask=~np.isfinite(blue_wing))),
-        ("peak_intensity", _make_cube(peak_intensity, cube.unit, mask=~np.isfinite(peak_intensity))),
-        ("peak_velocity", _make_cube(peak_velocity, u.km / u.s, mask=~np.isfinite(peak_velocity))),
-        ("quality", _make_cube(quality, u.dimensionless_unscaled)),
+        ("red_blue_asymmetry", red_blue, u.dimensionless_unscaled),
+        ("red_wing", red_wing, cube.unit),
+        ("blue_wing", blue_wing, cube.unit),
+        ("peak_intensity", peak_intensity, cube.unit),
+        ("peak_velocity", peak_velocity, u.km / u.s),
+        ("quality", quality, u.dimensionless_unscaled),
     ]
     if errors is not None:
         cubes.extend(
             [
-                (
-                    "red_blue_asymmetry_error",
-                    _make_cube(red_blue_error, u.dimensionless_unscaled, mask=~np.isfinite(red_blue_error)),
-                ),
-                ("red_wing_error", _make_cube(red_wing_error, cube.unit, mask=~np.isfinite(red_wing_error))),
-                ("blue_wing_error", _make_cube(blue_wing_error, cube.unit, mask=~np.isfinite(blue_wing_error))),
-            ],
+                ("red_blue_asymmetry_error", red_blue_error, u.dimensionless_unscaled),
+                ("red_wing_error", red_wing_error, cube.unit),
+                ("blue_wing_error", blue_wing_error, cube.unit),
+            ]
         )
+
+    result_cubes = []
+    for name, values, unit in cubes:
+        mask = None if name == "quality" else ~np.isfinite(values)
+        result_cubes.append((name, _make_cube(values, unit, mask=mask)))
 
     if return_profiles:
         observed_data = np.moveaxis(data, -1, wavelength_axis)
-        observed_mask = ~np.isfinite(observed_data)
-        observed_uncertainty = None
-        if errors is not None:
-            observed_uncertainty = StdDevUncertainty(np.moveaxis(errors, -1, wavelength_axis))
-
         interpolated_data = np.moveaxis(interpolated_profiles, -1, wavelength_axis)
+        observed_mask = ~np.isfinite(observed_data)
         interpolated_mask = ~np.isfinite(interpolated_data)
-        interpolated_uncertainty = None
-        if interpolated_errors is not None:
-            interpolated_uncertainty = StdDevUncertainty(np.moveaxis(interpolated_errors, -1, wavelength_axis))
+        observed_uncertainty = (
+            StdDevUncertainty(np.moveaxis(errors, -1, wavelength_axis)) if errors is not None else None
+        )
+        interpolated_uncertainty = (
+            StdDevUncertainty(np.moveaxis(interpolated_errors, -1, wavelength_axis))
+            if interpolated_errors is not None
+            else None
+        )
 
-        cubes.extend(
+        result_cubes.extend(
             [
                 (
                     "observed_profile",
@@ -512,4 +600,5 @@ def calculate_red_blue_asymmetry(
                 ),
             ]
         )
-    return RasterCollection(cubes)
+
+    return RasterCollection(result_cubes)

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -20,6 +20,9 @@ from irispy.utils._spectral import drop_extra_coords_dependent_on_axis, make_map
 
 __all__ = ["RBAQualityFlag", "calculate_red_blue_asymmetry"]
 
+# Minimum fraction of wing bins that must have finite interpolated values.
+_MIN_WING_COVERAGE = 0.8
+
 
 class RBAQualityFlag(IntEnum):
     """
@@ -182,6 +185,12 @@ def calculate_red_blue_asymmetry(
     Returns
     -------
     `irispy.spectrograph.RasterCollection`
+        Always contains ``"red_blue_asymmetry"`` and ``"quality"`` 2D maps.
+        ``"red_blue_asymmetry_error"`` is added when the input cube has uncertainty.
+        ``"observed_profile"`` and ``"interpolated_profile"`` 3D cubes are added
+        when ``return_profiles=True``. The interpolated profile velocity axis is
+        peak-centred; the observed profile velocity axis is relative to
+        ``rest_wavelength``.
     """
     if rest_wavelength is None:
         rest_wavelength = getattr(cube.meta, "rest_wavelength", None)
@@ -214,15 +223,11 @@ def calculate_red_blue_asymmetry(
         msg = "degree must be a non-negative integer"
         raise ValueError(msg)
 
-    try:
-        wavelength_axis = cube.wavelength_axis
-    except (AttributeError, StopIteration) as exc:
-        msg = "Could not identify a spectral wavelength axis on the input cube"
-        raise ValueError(msg) from exc
+    wavelength_axis = cube.wavelength_axis
     wavelengths = cube.axis_world_coords(wavelength_axis)[0].to(u.nm)
     rest_wavelength = rest_wavelength.to(wavelengths.unit)
     velocity = ((wavelengths - rest_wavelength) / rest_wavelength * constants.c).to_value(u.km / u.s)
-    interp_extent = velocity_high.to_value(u.km / u.s)
+    interp_extent = velocity_high.to_value(u.km / u.s) + dv
     interp_velocity = np.arange(-interp_extent, interp_extent + dv, dv)
     velocity_range_kms = (velocity_low.to_value(u.km / u.s), velocity_high.to_value(u.km / u.s))
 
@@ -245,12 +250,12 @@ def calculate_red_blue_asymmetry(
         min_intensity_value = (
             min_intensity.to_value(cube.unit) if isinstance(min_intensity, u.Quantity) else min_intensity
         )
-        quality = np.where(raw_peak < min_intensity_value, RBAQualityFlag.LOW_SIGNAL, quality)
+        quality = np.where(raw_peak < min_intensity_value, RBAQualityFlag.LOW_SIGNAL, quality).astype(np.uint8)
     if saturation_limit is not None:
         saturation_limit_value = (
             saturation_limit.to_value(cube.unit) if isinstance(saturation_limit, u.Quantity) else saturation_limit
         )
-        quality = np.where(raw_peak > saturation_limit_value, RBAQualityFlag.SATURATED, quality)
+        quality = np.where(raw_peak > saturation_limit_value, RBAQualityFlag.SATURATED, quality).astype(np.uint8)
 
     interpolated_profiles = (
         np.full((*output_shape, interp_velocity.size), np.nan, dtype=float) if return_profiles else None
@@ -262,7 +267,6 @@ def calculate_red_blue_asymmetry(
     )
 
     min_points = degree + 1
-    min_wing_coverage = 0.8
     for index in np.ndindex(output_shape):
         if quality[index] in (RBAQualityFlag.LOW_SIGNAL, RBAQualityFlag.SATURATED):
             continue
@@ -317,10 +321,10 @@ def calculate_red_blue_asymmetry(
 
         red_finite = red_mask & np.isfinite(interp_profile)
         blue_finite = blue_mask & np.isfinite(interp_profile)
-        if red_finite.sum() < min_wing_coverage * red_mask.sum():
+        if red_finite.sum() < _MIN_WING_COVERAGE * red_mask.sum():
             quality[index] = RBAQualityFlag.INCOMPLETE_WINGS
             continue
-        if blue_finite.sum() < min_wing_coverage * blue_mask.sum():
+        if blue_finite.sum() < _MIN_WING_COVERAGE * blue_mask.sum():
             quality[index] = RBAQualityFlag.INCOMPLETE_WINGS
             continue
 

--- a/irispy/utils/tests/test_red_blue.py
+++ b/irispy/utils/tests/test_red_blue.py
@@ -44,20 +44,12 @@ def test_calculate_red_blue_asymmetry_red_and_blue_signs():
     assert isinstance(result, RasterCollection)
     assert set(result.keys()) == {
         "red_blue_asymmetry",
-        "red_wing",
-        "blue_wing",
-        "peak_intensity",
-        "peak_velocity",
         "quality",
         "observed_profile",
         "interpolated_profile",
     }
     assert_quantity_allclose(result["red_blue_asymmetry"].data[0, 0] * u.one, 0.2 * u.one)
     assert_quantity_allclose(result["red_blue_asymmetry"].data[0, 1] * u.one, -0.3 * u.one)
-    assert_quantity_allclose(result["red_wing"].data[0, 0] * result["red_wing"].unit, 3 * u.DN)
-    assert_quantity_allclose(result["blue_wing"].data[0, 0] * result["blue_wing"].unit, 1 * u.DN)
-    assert_quantity_allclose(result["peak_intensity"].data[0, 0] * result["peak_intensity"].unit, 10 * u.DN)
-    assert result["peak_velocity"].unit == u.km / u.s
     assert result["quality"].unit == u.dimensionless_unscaled
     assert RBAQualityFlag(result["quality"].data[0, 0]) is RBAQualityFlag.OK
     assert RBAQualityFlag(result["quality"].data[0, 0]).description == "ok"
@@ -119,16 +111,12 @@ def test_calculate_red_blue_asymmetry_with_uncertainty():
     )
     assert "red_blue_asymmetry_error" in result
     assert result["red_blue_asymmetry_error"].unit == u.one
-    red_wing = float(result["red_wing"].data[0, 0])
-    blue_wing = float(result["blue_wing"].data[0, 0])
-    peak = float(result["peak_intensity"].data[0, 0])
-    numerator = red_wing - blue_wing
+    numerator = 2
+    peak = 10
     n_wing_bins = int((150 - 50) / 10) + 1
     wing_error = np.sqrt(np.sum(np.full(n_wing_bins, 0.1) ** 2)) / n_wing_bins
     expected_propagated_error = np.sqrt((np.sqrt(2) * wing_error / peak) ** 2 + (numerator * 0.1 / peak**2) ** 2)
     assert_quantity_allclose(result["red_blue_asymmetry_error"].data[0, 0] * u.one, expected_propagated_error * u.one)
-    assert result["red_wing_error"].unit == u.DN
-    assert result["blue_wing_error"].unit == u.DN
     assert result["red_blue_asymmetry"].meta["rba_rest_wavelength"] == 140.277
     assert result["red_blue_asymmetry"].meta["rba_interpolation_degree"] == 1
 

--- a/irispy/utils/tests/test_red_blue.py
+++ b/irispy/utils/tests/test_red_blue.py
@@ -194,7 +194,7 @@ def test_calculate_red_blue_asymmetry_return_profiles():
     assert isinstance(observed_cube, SpectrogramCube)
     assert isinstance(interp_cube, SpectrogramCube)
     assert observed_cube.data.shape == cube.shape
-    assert interp_cube.data.shape == (1, 2, 31)
+    assert interp_cube.data.shape == (1, 2, 33)
     assert "spect.dopplerVeloc" in observed_cube.wcs.world_axis_physical_types
     assert "spect.dopplerVeloc" in interp_cube.wcs.world_axis_physical_types
     assert interp_cube.uncertainty.array.shape == interp_cube.shape
@@ -211,10 +211,10 @@ def test_calculate_red_blue_asymmetry_return_profiles_on_sliced_cube():
 
     result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
     assert result["observed_profile"].shape == cube.shape
-    assert result["interpolated_profile"].shape == (2, 1, 31)
+    assert result["interpolated_profile"].shape == (2, 1, 33)
     assert_quantity_allclose(
         result["interpolated_profile"][0, 0].axis_world_coords(0)[0],
-        np.arange(-150, 151, 10) * u.km / u.s,
+        np.arange(-160, 161, 10) * u.km / u.s,
     )
 
 

--- a/irispy/utils/tests/test_red_blue.py
+++ b/irispy/utils/tests/test_red_blue.py
@@ -23,7 +23,7 @@ def _wavelengths_from_velocity(velocity):
 
 def _flat_wing_profile(velocity, *, red_excess=0, blue_excess=0):
     profile = np.ones(velocity.shape, dtype=float)
-    profile[np.abs(velocity.to_value(u.km / u.s)) <= 20] = 10
+    profile[np.isclose(velocity.to_value(u.km / u.s), 0)] = 10
     red = (velocity >= 50 * u.km / u.s) & (velocity <= 150 * u.km / u.s)
     blue = (velocity >= -150 * u.km / u.s) & (velocity <= -50 * u.km / u.s)
     profile[red] += red_excess
@@ -39,7 +39,7 @@ def test_calculate_red_blue_asymmetry_red_and_blue_signs():
     data = np.stack([red_profile, blue_profile]).reshape(1, 2, -1)
     cube = make_test_spectrogram_cube(data, wavelengths)
 
-    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
 
     assert isinstance(result, RasterCollection)
     assert set(result.keys()) == {
@@ -73,7 +73,7 @@ def test_calculate_red_blue_asymmetry_uses_masked_bins():
     red = (velocity >= 50 * u.km / u.s) & (velocity <= 150 * u.km / u.s)
     cube.mask[..., red] = True
 
-    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
     assert_quantity_allclose(result["red_blue_asymmetry"].data[0, 0] * u.one, 0 * u.one, atol=1e-12 * u.one)
 
 
@@ -87,7 +87,7 @@ def test_calculate_red_blue_asymmetry_output_does_not_inherit_first_wavelength_m
     cube.mask[0, 0, 0] = True
     cube.mask[0, 1, :] = True
 
-    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
     assert not result["red_blue_asymmetry"].mask[0, 0]
     assert result["quality"].data[0, 0] == 0
@@ -110,14 +110,12 @@ def test_calculate_red_blue_asymmetry_with_uncertainty():
     profile = _flat_wing_profile(velocity, red_excess=2)
     data = profile.reshape(1, 1, -1)
     cube = make_test_spectrogram_cube(data, wavelengths)
-    uncertainty = np.full(cube.shape, 0.1) * u.DN
+    cube.uncertainty = StdDevUncertainty(np.full(cube.shape, 0.1))
 
     result = calculate_red_blue_asymmetry(
         cube,
         rest_wavelength=REST_WAVELENGTH,
-        uncertainty=uncertainty,
         degree=1,
-        center_on_peak=False,
     )
     assert "red_blue_asymmetry_error" in result
     assert result["red_blue_asymmetry_error"].unit == u.one
@@ -132,15 +130,14 @@ def test_calculate_red_blue_asymmetry_with_uncertainty():
     assert result["red_wing_error"].unit == u.DN
     assert result["blue_wing_error"].unit == u.DN
     assert result["red_blue_asymmetry"].meta["rba_rest_wavelength"] == 140.277
-    assert result["red_blue_asymmetry"].meta["rba_center_on_peak"] is False
+    assert result["red_blue_asymmetry"].meta["rba_interpolation_degree"] == 1
 
     symmetric_cube = make_test_spectrogram_cube(_flat_wing_profile(velocity).reshape(1, 1, -1), wavelengths)
+    symmetric_cube.uncertainty = StdDevUncertainty(np.full(symmetric_cube.shape, 0.1))
     symmetric_result = calculate_red_blue_asymmetry(
         symmetric_cube,
         rest_wavelength=REST_WAVELENGTH,
-        uncertainty=uncertainty,
         degree=1,
-        center_on_peak=False,
     )
     expected_zero_error = np.sqrt(2) * wing_error / 10
     assert_quantity_allclose(symmetric_result["red_blue_asymmetry"].data[0, 0] * u.one, 0 * u.one)
@@ -162,19 +159,18 @@ def test_calculate_red_blue_asymmetry_flags_error_interpolation_failure(monkeypa
     velocity = np.arange(-200, 201, 10) * u.km / u.s
     wavelengths = _wavelengths_from_velocity(velocity)
     cube = make_test_spectrogram_cube(_flat_wing_profile(velocity, red_excess=2).reshape(1, 1, -1), wavelengths)
+    cube.uncertainty = StdDevUncertainty(np.full(cube.shape, 0.1))
 
     result = calculate_red_blue_asymmetry(
         cube,
         rest_wavelength=REST_WAVELENGTH,
-        uncertainty=np.full(cube.shape, 0.1) * u.DN,
         degree=1,
-        center_on_peak=False,
     )
     assert RBAQualityFlag(result["quality"].data[0, 0]) is RBAQualityFlag.INTERP_FAILED
     assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
 
 
-def test_calculate_red_blue_asymmetry_center_on_peak():
+def test_calculate_red_blue_asymmetry_centers_profiles_on_peak():
     velocity = np.arange(-200, 201, 10) * u.km / u.s
     wavelengths = _wavelengths_from_velocity(velocity)
     profile = np.ones(velocity.shape, dtype=float)
@@ -189,10 +185,7 @@ def test_calculate_red_blue_asymmetry_center_on_peak():
         cube,
         rest_wavelength=REST_WAVELENGTH,
         velocity_range=(50, 150) * u.km / u.s,
-        velocity_window=160 * u.km / u.s,
-        fit_window=190 * u.km / u.s,
         degree=1,
-        center_on_peak=True,
     )
     assert result["red_blue_asymmetry"].data[0, 0] > 0
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
@@ -206,13 +199,13 @@ def test_calculate_red_blue_asymmetry_return_profiles():
     cube = make_test_spectrogram_cube(data, wavelengths)
     cube.uncertainty = StdDevUncertainty(np.full(cube.shape, 0.1))
 
-    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
     observed_cube = result["observed_profile"]
     interp_cube = result["interpolated_profile"]
     assert isinstance(observed_cube, SpectrogramCube)
     assert isinstance(interp_cube, SpectrogramCube)
     assert observed_cube.data.shape == cube.shape
-    assert interp_cube.data.shape == (1, 2, 41)
+    assert interp_cube.data.shape == (1, 2, 31)
     assert "spect.dopplerVeloc" in observed_cube.wcs.world_axis_physical_types
     assert "spect.dopplerVeloc" in interp_cube.wcs.world_axis_physical_types
     assert interp_cube.uncertainty.array.shape == interp_cube.shape
@@ -227,12 +220,12 @@ def test_calculate_red_blue_asymmetry_return_profiles_on_sliced_cube():
     data = np.tile(profile, (2, 3, 1))
     cube = make_test_spectrogram_cube(data, wavelengths)[:, :1, :]
 
-    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
     assert result["observed_profile"].shape == cube.shape
-    assert result["interpolated_profile"].shape == (2, 1, 41)
+    assert result["interpolated_profile"].shape == (2, 1, 31)
     assert_quantity_allclose(
         result["interpolated_profile"][0, 0].axis_world_coords(0)[0],
-        np.arange(-200, 201, 10) * u.km / u.s,
+        np.arange(-150, 151, 10) * u.km / u.s,
     )
 
 
@@ -246,7 +239,6 @@ def test_calculate_red_blue_asymmetry_can_skip_profile_outputs():
         cube,
         rest_wavelength=REST_WAVELENGTH,
         degree=1,
-        center_on_peak=False,
         return_profiles=False,
     )
     assert "observed_profile" not in result
@@ -261,7 +253,7 @@ def test_calculate_red_blue_asymmetry_continuum_subtraction():
     data = (profile + 5).reshape(1, 1, -1)
     cube = make_test_spectrogram_cube(data, wavelengths)
 
-    result_without = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    result_without = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
 
     continuum_wavelengths = (
         u.Quantity([[wavelengths[0].value, wavelengths[2].value], [wavelengths[-3].value, wavelengths[-1].value]])
@@ -271,7 +263,6 @@ def test_calculate_red_blue_asymmetry_continuum_subtraction():
         cube,
         rest_wavelength=REST_WAVELENGTH,
         degree=1,
-        center_on_peak=False,
         continuum_windows=continuum_wavelengths,
     )
     rba_without = result_without["red_blue_asymmetry"].data[0, 0]
@@ -293,10 +284,7 @@ def test_calculate_red_blue_asymmetry_flags_incomplete_wings():
         cube,
         rest_wavelength=REST_WAVELENGTH,
         velocity_range=(50, 150) * u.km / u.s,
-        velocity_window=160 * u.km / u.s,
-        fit_window=190 * u.km / u.s,
         degree=1,
-        center_on_peak=True,
     )
     assert RBAQualityFlag(result["quality"].data[0, 0]) is RBAQualityFlag.INCOMPLETE_WINGS
     assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
@@ -320,7 +308,6 @@ def test_calculate_red_blue_asymmetry_quality_thresholds(option, value, expected
         cube,
         rest_wavelength=REST_WAVELENGTH,
         degree=1,
-        center_on_peak=False,
         **{option: value},
     )
     assert RBAQualityFlag(result["quality"].data[0, 0]) is expected_flag
@@ -334,7 +321,6 @@ def test_calculate_red_blue_asymmetry_real_cube_shape_and_coords(sns_sg_file):
         cube,
         rest_wavelength=133.29 * u.nm,
         velocity_range=(20, 60) * u.km / u.s,
-        velocity_window=80 * u.km / u.s,
         degree=1,
     )
     assert result["red_blue_asymmetry"].shape == cube.shape[:-1]
@@ -352,7 +338,7 @@ def test_calculate_red_blue_asymmetry_explicit_rest_wavelength():
     wavelengths = _wavelengths_from_velocity(velocity)
     profile = _flat_wing_profile(velocity, red_excess=2)
     cube = make_test_spectrogram_cube(profile.reshape(1, 1, -1), wavelengths)
-    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
 
 
@@ -378,7 +364,7 @@ def test_calculate_red_blue_asymmetry_auto_detect_rest_wavelength():
     meta = SGMeta(header, "Si IV 1403", data_shape=data.shape)
     cube.meta = meta
 
-    result = calculate_red_blue_asymmetry(cube, degree=1, center_on_peak=False)
+    result = calculate_red_blue_asymmetry(cube, degree=1)
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
     assert u.isclose(
         result["red_blue_asymmetry"].meta["rba_rest_wavelength"] * u.nm,
@@ -390,6 +376,6 @@ def test_calculate_red_blue_asymmetry_auto_detect_rest_wavelength():
 def test_calculate_red_blue_asymmetry_auto_detect_on_real_data(sns_sg_file):
     raster = read_files(sns_sg_file)
     cube = raster["C II 1336"][0]
-    result = calculate_red_blue_asymmetry(cube, degree=1, center_on_peak=False)
+    result = calculate_red_blue_asymmetry(cube, degree=1)
     assert "red_blue_asymmetry" in result
     assert result["red_blue_asymmetry"].shape == cube.shape[:-1]

--- a/irispy/utils/tests/test_red_blue.py
+++ b/irispy/utils/tests/test_red_blue.py
@@ -3,11 +3,13 @@ import pytest
 
 import astropy.units as u
 from astropy import constants
+from astropy.io import fits
 from astropy.nddata import StdDevUncertainty
 from astropy.tests.helper import assert_quantity_allclose
 
 import irispy.utils.red_blue as red_blue_module
 from irispy.io.utils import read_files
+from irispy.meta import SGMeta
 from irispy.spectrograph import RasterCollection, SpectrogramCube
 from irispy.tests.helpers import make_test_spectrogram_cube
 from irispy.utils.red_blue import RBAQualityFlag, calculate_red_blue_asymmetry
@@ -37,12 +39,7 @@ def test_calculate_red_blue_asymmetry_red_and_blue_signs():
     data = np.stack([red_profile, blue_profile]).reshape(1, 2, -1)
     cube = make_test_spectrogram_cube(data, wavelengths)
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
 
     assert isinstance(result, RasterCollection)
     assert set(result.keys()) == {
@@ -76,13 +73,7 @@ def test_calculate_red_blue_asymmetry_uses_masked_bins():
     red = (velocity >= 50 * u.km / u.s) & (velocity <= 150 * u.km / u.s)
     cube.mask[..., red] = True
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
-
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
     assert_quantity_allclose(result["red_blue_asymmetry"].data[0, 0] * u.one, 0 * u.one, atol=1e-12 * u.one)
 
 
@@ -96,13 +87,7 @@ def test_calculate_red_blue_asymmetry_output_does_not_inherit_first_wavelength_m
     cube.mask[0, 0, 0] = True
     cube.mask[0, 1, :] = True
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
-
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
     assert not result["red_blue_asymmetry"].mask[0, 0]
     assert result["quality"].data[0, 0] == 0
@@ -115,7 +100,6 @@ def test_calculate_red_blue_asymmetry_requires_wavelength_axis():
     cube.wcs.wcs.ctype[0] = "TIME"
     cube.wcs.wcs.cunit[0] = "s"
     cube.wcs.wcs.set()
-
     with pytest.raises(ValueError, match="Could not identify a spectral wavelength axis"):
         calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH)
 
@@ -132,53 +116,44 @@ def test_calculate_red_blue_asymmetry_with_uncertainty():
         cube,
         rest_wavelength=REST_WAVELENGTH,
         uncertainty=uncertainty,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
     )
-
     assert "red_blue_asymmetry_error" in result
     assert result["red_blue_asymmetry_error"].unit == u.one
     red_wing = float(result["red_wing"].data[0, 0])
     blue_wing = float(result["blue_wing"].data[0, 0])
     peak = float(result["peak_intensity"].data[0, 0])
     numerator = red_wing - blue_wing
-    wing_error = np.sqrt(np.sum(np.full(11, 0.1) ** 2)) / 11
+    n_wing_bins = int((150 - 50) / 10) + 1
+    wing_error = np.sqrt(np.sum(np.full(n_wing_bins, 0.1) ** 2)) / n_wing_bins
     expected_propagated_error = np.sqrt((np.sqrt(2) * wing_error / peak) ** 2 + (numerator * 0.1 / peak**2) ** 2)
-    assert_quantity_allclose(
-        result["red_blue_asymmetry_error"].data[0, 0] * u.one,
-        expected_propagated_error * u.one,
-    )
+    assert_quantity_allclose(result["red_blue_asymmetry_error"].data[0, 0] * u.one, expected_propagated_error * u.one)
+    assert result["red_wing_error"].unit == u.DN
+    assert result["blue_wing_error"].unit == u.DN
+    assert result["red_blue_asymmetry"].meta["rba_rest_wavelength"] == 140.277
+    assert result["red_blue_asymmetry"].meta["rba_center_on_peak"] is False
 
     symmetric_cube = make_test_spectrogram_cube(_flat_wing_profile(velocity).reshape(1, 1, -1), wavelengths)
     symmetric_result = calculate_red_blue_asymmetry(
         symmetric_cube,
         rest_wavelength=REST_WAVELENGTH,
         uncertainty=uncertainty,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
     )
     expected_zero_error = np.sqrt(2) * wing_error / 10
     assert_quantity_allclose(symmetric_result["red_blue_asymmetry"].data[0, 0] * u.one, 0 * u.one)
     assert_quantity_allclose(
-        symmetric_result["red_blue_asymmetry_error"].data[0, 0] * u.one,
-        expected_zero_error * u.one,
+        symmetric_result["red_blue_asymmetry_error"].data[0, 0] * u.one, expected_zero_error * u.one
     )
-
-    assert result["red_wing_error"].unit == u.DN
-    assert result["blue_wing_error"].unit == u.DN
-    # Meta should record the parameters used
-    assert result["red_blue_asymmetry"].meta["rba_rest_wavelength"] == 140.277
-    assert result["red_blue_asymmetry"].meta["rba_center_on_peak"] is False
 
 
 def test_calculate_red_blue_asymmetry_flags_error_interpolation_failure(monkeypatch):
     original_make_interp_spline = red_blue_module.make_interp_spline
-    calls = 0
 
     def fail_on_error_spline(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        if calls == 2:
+        if np.allclose(np.asarray(args[1]), 0.1):
             msg = "error spline failed"
             raise ValueError(msg)
         return original_make_interp_spline(*args, **kwargs)
@@ -192,28 +167,21 @@ def test_calculate_red_blue_asymmetry_flags_error_interpolation_failure(monkeypa
         cube,
         rest_wavelength=REST_WAVELENGTH,
         uncertainty=np.full(cube.shape, 0.1) * u.DN,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
     )
-
     assert RBAQualityFlag(result["quality"].data[0, 0]) is RBAQualityFlag.INTERP_FAILED
     assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
 
 
 def test_calculate_red_blue_asymmetry_center_on_peak():
-    """
-    Test that center_on_peak=True correctly aligns a Doppler-shifted line.
-    """
     velocity = np.arange(-200, 201, 10) * u.km / u.s
     wavelengths = _wavelengths_from_velocity(velocity)
-    # Create a line peaked at +30 km/s with red excess
     profile = np.ones(velocity.shape, dtype=float)
     peak_wvl = _wavelengths_from_velocity(30 * u.km / u.s)
     sigma_wvl = abs(_wavelengths_from_velocity(10 * u.km / u.s) - peak_wvl).value
     profile += 9 * np.exp(-0.5 * ((wavelengths.value - peak_wvl.value) / sigma_wvl) ** 2)
-    # Add red wing excess
-    red = (velocity >= 50 * u.km / u.s) & (velocity <= 150 * u.km / u.s)
-    profile[red] += 2
+    profile[(velocity >= 50 * u.km / u.s) & (velocity <= 150 * u.km / u.s)] += 2
     data = profile.reshape(1, 1, -1)
     cube = make_test_spectrogram_cube(data, wavelengths)
 
@@ -223,14 +191,10 @@ def test_calculate_red_blue_asymmetry_center_on_peak():
         velocity_range=(50, 150) * u.km / u.s,
         velocity_window=160 * u.km / u.s,
         fit_window=190 * u.km / u.s,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=True,
     )
-
-    # Positive RBA because red wing has excess
     assert result["red_blue_asymmetry"].data[0, 0] > 0
-    # With center_on_peak=True the peak should be found and aligned, so the
-    # blue wing (now centered on the peak) should NOT have the excess.
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
 
 
@@ -242,16 +206,7 @@ def test_calculate_red_blue_asymmetry_return_profiles():
     cube = make_test_spectrogram_cube(data, wavelengths)
     cube.uncertainty = StdDevUncertainty(np.full(cube.shape, 0.1))
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
-
-    assert isinstance(result, RasterCollection)
-    assert "observed_profile" in result
-    assert "interpolated_profile" in result
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
     observed_cube = result["observed_profile"]
     interp_cube = result["interpolated_profile"]
     assert isinstance(observed_cube, SpectrogramCube)
@@ -261,14 +216,8 @@ def test_calculate_red_blue_asymmetry_return_profiles():
     assert "spect.dopplerVeloc" in observed_cube.wcs.world_axis_physical_types
     assert "spect.dopplerVeloc" in interp_cube.wcs.world_axis_physical_types
     assert interp_cube.uncertainty.array.shape == interp_cube.shape
-
-    observed_profile = observed_cube[0, 0]
-    interp_profile = interp_cube[0, 1]
-    assert observed_profile.data.shape == (41,)
-    assert interp_profile.data.shape == (41,)
-    assert_quantity_allclose(observed_profile.axis_world_coords(0)[0], velocity)
-    assert_quantity_allclose(interp_profile.axis_world_coords(0)[0], np.arange(-200, 201, 10) * u.km / u.s)
-    assert np.isfinite(interp_profile.data).all()
+    assert_quantity_allclose(observed_cube[0, 0].axis_world_coords(0)[0], velocity)
+    assert np.isfinite(interp_cube[0, 1].data).all()
 
 
 def test_calculate_red_blue_asymmetry_return_profiles_on_sliced_cube():
@@ -278,13 +227,7 @@ def test_calculate_red_blue_asymmetry_return_profiles_on_sliced_cube():
     data = np.tile(profile, (2, 3, 1))
     cube = make_test_spectrogram_cube(data, wavelengths)[:, :1, :]
 
-    result = calculate_red_blue_asymmetry(
-        cube,
-        rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
-        center_on_peak=False,
-    )
-
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
     assert result["observed_profile"].shape == cube.shape
     assert result["interpolated_profile"].shape == (2, 1, 41)
     assert_quantity_allclose(
@@ -302,14 +245,40 @@ def test_calculate_red_blue_asymmetry_can_skip_profile_outputs():
     result = calculate_red_blue_asymmetry(
         cube,
         rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
         return_profiles=False,
     )
-
     assert "observed_profile" not in result
     assert "interpolated_profile" not in result
     assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
+
+
+def test_calculate_red_blue_asymmetry_continuum_subtraction():
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    profile = _flat_wing_profile(velocity, red_excess=2)
+    data = (profile + 5).reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wavelengths)
+
+    result_without = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+
+    continuum_wavelengths = (
+        u.Quantity([[wavelengths[0].value, wavelengths[2].value], [wavelengths[-3].value, wavelengths[-1].value]])
+        * wavelengths.unit
+    )
+    result_with = calculate_red_blue_asymmetry(
+        cube,
+        rest_wavelength=REST_WAVELENGTH,
+        degree=1,
+        center_on_peak=False,
+        continuum_windows=continuum_wavelengths,
+    )
+    rba_without = result_without["red_blue_asymmetry"].data[0, 0]
+    rba_with = result_with["red_blue_asymmetry"].data[0, 0]
+    assert np.isfinite(rba_with)
+    assert_quantity_allclose(rba_with * u.one, (2 / 9) * u.one)
+    assert not np.isclose(rba_without, rba_with)
 
 
 def test_calculate_red_blue_asymmetry_flags_incomplete_wings():
@@ -326,22 +295,21 @@ def test_calculate_red_blue_asymmetry_flags_incomplete_wings():
         velocity_range=(50, 150) * u.km / u.s,
         velocity_window=160 * u.km / u.s,
         fit_window=190 * u.km / u.s,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=True,
     )
-
     assert RBAQualityFlag(result["quality"].data[0, 0]) is RBAQualityFlag.INCOMPLETE_WINGS
     assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
 
 
 @pytest.mark.parametrize(
-    ("option", "value", "expected_reason"),
+    ("option", "value", "expected_flag"),
     [
-        ("min_intensity", 15, "below min_intensity"),
-        ("saturation_limit", 5, "above saturation_limit"),
+        ("min_intensity", 15, RBAQualityFlag.LOW_SIGNAL),
+        ("saturation_limit", 5, RBAQualityFlag.SATURATED),
     ],
 )
-def test_calculate_red_blue_asymmetry_quality_thresholds(option, value, expected_reason):
+def test_calculate_red_blue_asymmetry_quality_thresholds(option, value, expected_flag):
     velocity = np.arange(-200, 201, 10) * u.km / u.s
     wavelengths = _wavelengths_from_velocity(velocity)
     profile = _flat_wing_profile(velocity, red_excess=2)
@@ -351,12 +319,11 @@ def test_calculate_red_blue_asymmetry_quality_thresholds(option, value, expected
     result = calculate_red_blue_asymmetry(
         cube,
         rest_wavelength=REST_WAVELENGTH,
-        interpolation_kind="linear",
+        degree=1,
         center_on_peak=False,
         **{option: value},
     )
-
-    assert RBAQualityFlag(result["quality"].data[0, 0]).description == expected_reason
+    assert RBAQualityFlag(result["quality"].data[0, 0]) is expected_flag
     assert np.isnan(result["red_blue_asymmetry"].data[0, 0])
 
 
@@ -368,8 +335,61 @@ def test_calculate_red_blue_asymmetry_real_cube_shape_and_coords(sns_sg_file):
         rest_wavelength=133.29 * u.nm,
         velocity_range=(20, 60) * u.km / u.s,
         velocity_window=80 * u.km / u.s,
-        interpolation_kind="linear",
+        degree=1,
     )
-
     assert result["red_blue_asymmetry"].shape == cube.shape[:-1]
     assert "time" in tuple(result["red_blue_asymmetry"].extra_coords.keys())
+
+
+def test_calculate_red_blue_asymmetry_rest_wavelength_required_without_meta():
+    cube = make_test_spectrogram_cube(np.ones((1, 1, 5)), np.arange(5) * u.nm)
+    with pytest.raises(ValueError, match="rest_wavelength"):
+        calculate_red_blue_asymmetry(cube, degree=1)
+
+
+def test_calculate_red_blue_asymmetry_explicit_rest_wavelength():
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    profile = _flat_wing_profile(velocity, red_excess=2)
+    cube = make_test_spectrogram_cube(profile.reshape(1, 1, -1), wavelengths)
+    result = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1, center_on_peak=False)
+    assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
+
+
+def test_calculate_red_blue_asymmetry_auto_detect_rest_wavelength():
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    profile = _flat_wing_profile(velocity, red_excess=2)
+    data = profile.reshape(1, 1, -1)
+    cube = make_test_spectrogram_cube(data, wavelengths)
+
+    header = fits.Header(cube.wcs.to_header())
+    header["INSTRUME"] = "IRIS"
+    header["TELESCOP"] = "IRIS"
+    header["DATA_LEV"] = 2
+    header["OBSID"] = 1
+    header["OBS_DESC"] = "Test obs"
+    header["NWIN"] = 1
+    header["TDESC1"] = "Si IV 1403"
+    header["TWAVE1"] = REST_WAVELENGTH.to(u.AA).value
+    header["TWMIN1"] = (wavelengths[0] - 0.5 * u.nm).to(u.AA).value
+    header["TWMAX1"] = (wavelengths[-1] + 0.5 * u.nm).to(u.AA).value
+    header["TDET1"] = "FUV2"
+    meta = SGMeta(header, "Si IV 1403", data_shape=data.shape)
+    cube.meta = meta
+
+    result = calculate_red_blue_asymmetry(cube, degree=1, center_on_peak=False)
+    assert np.isfinite(result["red_blue_asymmetry"].data[0, 0])
+    assert u.isclose(
+        result["red_blue_asymmetry"].meta["rba_rest_wavelength"] * u.nm,
+        REST_WAVELENGTH,
+        rtol=1e-4,
+    )
+
+
+def test_calculate_red_blue_asymmetry_auto_detect_on_real_data(sns_sg_file):
+    raster = read_files(sns_sg_file)
+    cube = raster["C II 1336"][0]
+    result = calculate_red_blue_asymmetry(cube, degree=1, center_on_peak=False)
+    assert "red_blue_asymmetry" in result
+    assert result["red_blue_asymmetry"].shape == cube.shape[:-1]

--- a/irispy/utils/tests/test_red_blue.py
+++ b/irispy/utils/tests/test_red_blue.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -11,7 +12,7 @@ import irispy.utils.red_blue as red_blue_module
 from irispy.io.utils import read_files
 from irispy.meta import SGMeta
 from irispy.spectrograph import RasterCollection, SpectrogramCube
-from irispy.tests.helpers import make_test_spectrogram_cube
+from irispy.tests.helpers import figure_test, make_test_spectrogram_cube
 from irispy.utils.red_blue import RBAQualityFlag, calculate_red_blue_asymmetry
 
 REST_WAVELENGTH = 140.277 * u.nm
@@ -258,6 +259,50 @@ def test_calculate_red_blue_asymmetry_continuum_subtraction():
     assert np.isfinite(rba_with)
     assert_quantity_allclose(rba_with * u.one, (2 / 9) * u.one)
     assert not np.isclose(rba_without, rba_with)
+
+
+@figure_test
+def test_calculate_red_blue_asymmetry_continuum_figure():
+    velocity = np.arange(-200, 201, 10) * u.km / u.s
+    wavelengths = _wavelengths_from_velocity(velocity)
+    profile = _flat_wing_profile(velocity, red_excess=2)
+    cube = make_test_spectrogram_cube((profile + 5).reshape(1, 1, -1), wavelengths)
+    continuum_wavelengths = (
+        u.Quantity([[wavelengths[0].value, wavelengths[2].value], [wavelengths[-3].value, wavelengths[-1].value]])
+        * wavelengths.unit
+    )
+
+    result_without = calculate_red_blue_asymmetry(cube, rest_wavelength=REST_WAVELENGTH, degree=1)
+    result_with = calculate_red_blue_asymmetry(
+        cube,
+        rest_wavelength=REST_WAVELENGTH,
+        degree=1,
+        continuum_windows=continuum_wavelengths,
+    )
+    rba_without = float(result_without["red_blue_asymmetry"].data[0, 0])
+    rba_with = float(result_with["red_blue_asymmetry"].data[0, 0])
+    assert_quantity_allclose(rba_without * u.one, (2 / 15) * u.one)
+    assert_quantity_allclose(rba_with * u.one, (2 / 9) * u.one)
+
+    raw_profile = result_without["observed_profile"][0, 0]
+    continuum_profile = result_with["observed_profile"][0, 0]
+    velocities = raw_profile.axis_world_coords(0)[0].to_value(u.km / u.s)
+    v_low, v_high = 50, 150
+
+    fig, axes = plt.subplots(1, 2, figsize=(9, 3.5), constrained_layout=True)
+    axes[0].plot(velocities, raw_profile.data, "o-", color="0.2", markersize=3, label="Input + continuum")
+    axes[0].plot(velocities, continuum_profile.data, "o-", color="C3", markersize=3, label="Continuum subtracted")
+    axes[0].axvspan(-v_high, -v_low, color="C0", alpha=0.12)
+    axes[0].axvspan(v_low, v_high, color="C3", alpha=0.12)
+    axes[0].set(xlabel="Velocity [km/s]", ylabel="Intensity [DN]", title="Profiles")
+    axes[0].legend(fontsize=8)
+
+    axes[1].bar(["Raw", "Subtracted"], [rba_without, rba_with], color=["0.5", "C3"])
+    axes[1].axhline(0, color="0.2", linewidth=0.8)
+    axes[1].set(ylabel="Red-Blue Asymmetry", title="Continuum correction")
+    axes[1].set_ylim(0, 0.26)
+
+    return fig
 
 
 def test_calculate_red_blue_asymmetry_flags_incomplete_wings():


### PR DESCRIPTION
## Summary by Sourcery

Refactor the red–blue asymmetry computation to simplify its API and outputs, add automatic rest-wavelength handling, and improve data preparation and continuum treatment while tightening quality flagging and error propagation.

New Features:
- Support automatic rest-wavelength detection from SGMeta metadata when rest_wavelength is not explicitly provided.
- Add optional continuum subtraction based on user-specified wavelength windows before computing red–blue asymmetries.

Enhancements:
- Simplify calculate_red_blue_asymmetry parameters by replacing interpolation_kind with an integer spline degree and removing redundant windowing and centering options.
- Restrict the primary outputs to asymmetry, its uncertainty, and quality flags, dropping per-wing and peak diagnostic cubes to streamline results.
- Improve interpolation, masking, and quality-flag logic for more robust handling of edge cases and incomplete line wings.
- Update the red–blue asymmetry example to rely on metadata-based rest wavelength and to use the numeric RBAQualityFlag values when masking.

Documentation:
- Add a breaking-change changelog entry describing the updated red–blue asymmetry API and behavior.
- Refresh the red–blue asymmetry analysis example to match the new API and recommended usage.

Tests:
- Substantially update and extend unit tests for calculate_red_blue_asymmetry, including new coverage of continuum subtraction, error propagation, rest-wavelength auto-detection, real-data behavior, and figure-based regression tests.