### PR TITLE
Spec0 action run on v1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ permissions: {}
 
 jobs:
   core:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@4193751d511425d4edc1d5657c24b2128d49b017  # v2.6.4
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@afacbe8ebafa67b369e1f605b4f6989284ba2e87  # v2.6.5
     with:
       submodules: false
       coverage: codecov
@@ -60,7 +60,7 @@ jobs:
 
   test:
     needs: [core, sdist_verify]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@4193751d511425d4edc1d5657c24b2128d49b017  # v2.6.4
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@afacbe8ebafa67b369e1f605b4f6989284ba2e87  # v2.6.5
     with:
       submodules: false
       coverage: codecov
@@ -82,7 +82,7 @@ jobs:
 
   docs:
     needs: [core]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@4193751d511425d4edc1d5657c24b2128d49b017  # v2.6.4
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@afacbe8ebafa67b369e1f605b4f6989284ba2e87  # v2.6.5
     with:
       default_python: '3.13'
       submodules: false
@@ -104,7 +104,7 @@ jobs:
   online:
     if: "!startsWith(github.event.ref, 'refs/tags/v')"
     needs: [docs]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@4193751d511425d4edc1d5657c24b2128d49b017 # v2.6.4
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@afacbe8ebafa67b369e1f605b4f6989284ba2e87 # v2.6.5
     with:
       default_python: '3.13'
       submodules: false
@@ -135,7 +135,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'Run publish')
       )
     needs: [test, docs]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@4193751d511425d4edc1d5657c24b2128d49b017  # v2.6.4
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@afacbe8ebafa67b369e1f605b4f6989284ba2e87  # v2.6.5
     with:
       python-version: '3.13'
       libraries: "ffmpeg"

--- a/.github/workflows/update-spec0.yaml
+++ b/.github/workflows/update-spec0.yaml
@@ -13,6 +13,6 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: scientific-python/spec0-action@8b8b76f254aecce36e6f07de7dde174cb3cafa81  # v1.3
+      - uses: scientific-python/spec0-action@6d7df2702c1dfc225a7ce5918616db9a6a652901  # v1.4
         with:
           update_all: 2  # also bump non-SPEC0 deps older than 2 years

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,34 +46,34 @@ optional-dependencies.all = [
   "irispy-lmsal[cosmic-rays,density]",
 ]
 optional-dependencies.cosmic-rays = [
-  "astroscrappy",
-  "rsliding",
+  "astroscrappy>=1.3.0",
+  "rsliding>=1.0.0",
 ]
 optional-dependencies.density = [
-  "fiasco",
+  "fiasco>=0.3.0",
 ]
 optional-dependencies.dev = [
   "irispy-lmsal[all,docs,tests]",
 ]
 optional-dependencies.docs = [
   "irispy-lmsal[all]",
-  "aiapy",
-  "dask[distributed]",
-  "pooch",
-  "sphinx-automodapi",
-  "sphinx-changelog",
+  "aiapy>=0.9.0",
+  "dask[distributed]>=2024.6.0",
+  "pooch>=1.9.0",
+  "sphinx-automodapi>=0.18.0",
+  "sphinx-changelog>=1.6.0",
   "sphinx-copybutton",
-  "sphinx-design",
-  "sphinx-gallery",
-  "sphinx",
-  "sunkit-image",
-  "sunpy-sphinx-theme",
+  "sphinx-design>=0.6.1",
+  "sphinx-gallery>=0.17.0",
+  "sphinx>=7.4.0",
+  "sunkit-image>=0.6.0",
+  "sunpy-sphinx-theme>=2.0.13",
 ]
 optional-dependencies.tests = [
   "irispy-lmsal[all]",
-  "pooch",
+  "pooch>=1.9.0",
   "pytest-astropy",
-  "pytest-mpl",
+  "pytest-mpl>=0.18.0",
 ]
 urls.Changelog = "https://irispy.readthedocs.io/en/stable/changelog"
 urls.Documentation = "https://irispy.readthedocs.io/en/stable/"


### PR DESCRIPTION
## Summary by Sourcery

Update dependency version constraints and CI workflows to align with newer tooling and the latest scientific-python spec0 action.

Enhancements:
- Tighten optional dependency specifications by adding minimum supported versions for docs, tests, cosmic-rays, and density extras.

CI:
- Bump OpenAstronomy reusable GitHub Actions workflows from v2.6.4 to v2.6.5 for core, test, docs, online, and publish jobs.
- Update the scientific-python spec0 GitHub Action to v1.4 in the spec0 update workflow.