### PR TITLE
Extract independent cleanup fixes

### DIFF
--- a/irispy/tests/test_sji.py
+++ b/irispy/tests/test_sji.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 
 import sunpy.map
@@ -68,3 +69,19 @@ def test_to_map(sns_sjicube_1330):
     assert isinstance(output, sunpy.map.mapsequence.MapSequence)
     assert output.data.shape == (40, 37, 52)
     assert np.all([output.reference_date is not None for output in output])
+
+
+def test_sji_plot_uses_short_slider_label(sns_sjicube_1330):
+    fig = plt.figure()
+    animator = sns_sjicube_1330.plot(fig=fig)
+
+    assert animator.slider_labels == ["Time"]
+    plt.close(fig)
+
+
+def test_sji_plot_accepts_custom_slider_label(sns_sjicube_1330):
+    fig = plt.figure()
+    animator = sns_sjicube_1330.plot(fig=fig, slider_labels=["Frame"])
+
+    assert animator.slider_labels == ["Frame"]
+    plt.close(fig)

--- a/irispy/utils/cosmic_rays.py
+++ b/irispy/utils/cosmic_rays.py
@@ -6,6 +6,7 @@ from typing import Any
 from importlib import import_module
 from collections.abc import Mapping
 
+import dask.array as da
 import numpy as np
 
 __all__ = ["remove_cosmic_rays"]
@@ -24,8 +25,8 @@ def _import_optional_backend(module_name: str, *, method: str):
 
 
 def _remove_cosmic_rays_rsliding(
-    data: np.ndarray,
-    mask: np.ndarray,
+    data,
+    mask,
     *,
     sigma: float | None,
     max_iters: int | None,
@@ -46,6 +47,17 @@ def _remove_cosmic_rays_rsliding(
     return cleaned_data, cosmic_ray_mask
 
 
+def _mask_for_frame(mask, index, data_shape, frame_shape):
+    if mask is None:
+        return np.zeros(frame_shape, dtype=bool)
+    mask_shape = getattr(mask, "shape", np.shape(mask))
+    if mask_shape == frame_shape:
+        return np.asarray(mask, dtype=bool)
+    if mask_shape == data_shape:
+        return np.asarray(mask[index], dtype=bool)
+    return np.asarray(np.broadcast_to(mask, data_shape)[index], dtype=bool)
+
+
 def _remove_cosmic_rays_astroscrappy(
     data: np.ndarray,
     mask: np.ndarray,
@@ -62,20 +74,19 @@ def _remove_cosmic_rays_astroscrappy(
     if max_iters is not None:
         method_kwargs["niter"] = max_iters
     inmask = method_kwargs.pop("inmask", None)
-    if inmask is not None:
-        mask = mask | np.asarray(inmask, dtype=bool)
-    working_data = data.copy()
-    working_data[mask] = 0.0
-    cleaned_data = np.empty_like(working_data)
-    cosmic_ray_mask = np.zeros(working_data.shape, dtype=bool)
-    if working_data.ndim == 2:
-        cosmic_ray_mask, cleaned_data = astroscrappy.detect_cosmics(working_data, inmask=mask, **method_kwargs)
-        return cleaned_data, np.asarray(cosmic_ray_mask, dtype=bool)
-    for index in np.ndindex(working_data.shape[:-2]):
-        frame_mask, cleaned_frame = astroscrappy.detect_cosmics(
-            working_data[index], inmask=mask[index], **method_kwargs
-        )
-        cosmic_ray_mask[index] = frame_mask
+    data_shape = data.shape
+    cleaned_data = np.empty(data_shape, dtype=data.dtype)
+    cosmic_ray_mask = np.zeros(data_shape, dtype=bool)
+    for index in np.ndindex(data_shape[:-2]):
+        frame = np.asarray(data[index]).copy()
+        frame_mask = _mask_for_frame(mask, index, data_shape, frame.shape)
+        if np.issubdtype(frame.dtype, np.floating):
+            frame_mask = frame_mask | np.isnan(frame)
+        if inmask is not None:
+            frame_mask = frame_mask | _mask_for_frame(inmask, index, data_shape, frame.shape)
+        frame[frame_mask] = 0.0
+        detected_mask, cleaned_frame = astroscrappy.detect_cosmics(frame, inmask=frame_mask, **method_kwargs)
+        cosmic_ray_mask[index] = detected_mask
         cleaned_data[index] = cleaned_frame
     return cleaned_data, cosmic_ray_mask
 
@@ -105,6 +116,8 @@ def remove_cosmic_rays(
         ``rsliding`` and ``niter`` for ``astroscrappy``.
     method_kwargs : `dict`, optional
         Additional keyword arguments passed to the selected backend.
+        For dask-backed inputs, ``method="astroscrappy"`` processes one frame
+        at a time but returns an in-memory NumPy array.
 
     Returns
     -------
@@ -112,10 +125,20 @@ def remove_cosmic_rays(
         A new cube with cleaned data and copied metadata/coordinates.
     """
     method = method.lower()
-    working_mask = np.zeros(cube.data.shape, dtype=bool) if cube.mask is None else np.asarray(cube.mask, dtype=bool)
-    if np.issubdtype(cube.data.dtype, np.floating):
-        working_mask = working_mask | np.isnan(cube.data)
     kwargs = dict(method_kwargs or {})
+    dask_backed = isinstance(cube.data, da.Array) or isinstance(cube.mask, da.Array)
+    if dask_backed and method == "rsliding":
+        msg = (
+            "remove_cosmic_rays(method='rsliding') requires the full cube in memory. "
+            "Slice the cube first, load it without memmap=True, or use method='astroscrappy'."
+        )
+        raise ValueError(msg)
+
+    working_mask = None
+    if not dask_backed:
+        working_mask = np.zeros(cube.data.shape, dtype=bool) if cube.mask is None else np.asarray(cube.mask, dtype=bool)
+        if np.issubdtype(cube.data.dtype, np.floating):
+            working_mask = working_mask | np.isnan(cube.data)
     backends = {
         "rsliding": lambda: _remove_cosmic_rays_rsliding(
             cube.data,
@@ -126,7 +149,7 @@ def remove_cosmic_rays(
         ),
         "astroscrappy": lambda: _remove_cosmic_rays_astroscrappy(
             cube.data,
-            working_mask,
+            cube.mask if dask_backed else working_mask,
             sigma=sigma,
             max_iters=max_iters,
             method_kwargs=kwargs,

--- a/irispy/utils/red_blue.py
+++ b/irispy/utils/red_blue.py
@@ -13,8 +13,6 @@ from astropy import constants
 from astropy.nddata import StdDevUncertainty
 from astropy.wcs import WCS
 
-from ndcube.wcs.tools import unwrap_wcs_to_fitswcs
-
 from irispy.spectrograph import RasterCollection, SpectrogramCube
 from irispy.utils._spectral import drop_extra_coords_dependent_on_axis, make_map_cube, make_spatial_template
 
@@ -46,45 +44,32 @@ class RBAQualityFlag(IntEnum):
         return obj
 
 
-def _make_velocity_wcs(base_wcs, array_shape, velocity_axis, velocity_grid):
-    fits_wcs = base_wcs if hasattr(base_wcs, "to_header") else unwrap_wcs_to_fitswcs(base_wcs)[0]
-    header = fits_wcs.to_header()
+def _make_velocity_wcs(array_shape, velocity_axis, velocity_grid):
+    """
+    Return a profile WCS whose only meaningful world axis is Doppler velocity.
+
+    Do not copy the input cube WCS here: profile cubes may have fewer axes than
+    the source cube, so stale FITS-WCS axes can warn or fail during construction.
+    """
     naxis = len(array_shape)
     wcs_axis = naxis - 1 - velocity_axis
-    fits_axis = wcs_axis + 1
-
-    header["NAXIS"] = naxis
-    for array_axis, length in enumerate(array_shape):
-        header[f"NAXIS{naxis - array_axis}"] = int(length)
-
     cdelt = float(np.nanmean(np.diff(velocity_grid))) if velocity_grid.size > 1 else 1.0
-    header[f"CTYPE{fits_axis}"] = "VELO"
-    header[f"CUNIT{fits_axis}"] = "km/s"
-    header[f"CRPIX{fits_axis}"] = 1.0
-    header[f"CRVAL{fits_axis}"] = float(velocity_grid[0])
-    header[f"CDELT{fits_axis}"] = cdelt
-    header.pop(f"CNAME{fits_axis}", None)
 
-    for other_axis in range(1, naxis + 1):
-        for prefix in ("CD",):
-            header.pop(f"{prefix}{fits_axis}_{other_axis}", None)
-            header.pop(f"{prefix}{other_axis}_{fits_axis}", None)
-        if other_axis != fits_axis:
-            header[f"PC{fits_axis}_{other_axis}"] = 0.0
-            header[f"PC{other_axis}_{fits_axis}"] = 0.0
-    header[f"PC{fits_axis}_{fits_axis}"] = 1.0
-
-    for key in list(header):
-        if key.startswith((f"PV{fits_axis}_", f"PS{fits_axis}_")):
-            header.pop(key)
-
-    return WCS(header)
+    wcs = WCS(naxis=naxis)
+    wcs.wcs.ctype[wcs_axis] = "VELO"
+    wcs.wcs.cunit[wcs_axis] = "km/s"
+    wcs.wcs.crpix[wcs_axis] = 1.0
+    wcs.wcs.crval[wcs_axis] = float(velocity_grid[0])
+    wcs.wcs.cdelt[wcs_axis] = cdelt
+    wcs.array_shape = tuple(array_shape)
+    wcs.wcs.set()
+    return wcs
 
 
 def _make_profile_cube(cube, *, data, velocity_grid, wavelength_axis, meta, uncertainty=None, mask=None):
     return SpectrogramCube(
         data,
-        wcs=_make_velocity_wcs(cube.wcs, data.shape, wavelength_axis, velocity_grid),
+        wcs=_make_velocity_wcs(data.shape, wavelength_axis, velocity_grid),
         uncertainty=uncertainty,
         unit=cube.unit,
         meta=meta,

--- a/irispy/utils/tests/test_cosmic_rays.py
+++ b/irispy/utils/tests/test_cosmic_rays.py
@@ -1,9 +1,19 @@
 import types
 
+import dask.array as da
 import numpy as np
 import pytest
 
 from irispy.utils.cosmic_rays import remove_cosmic_rays
+
+
+class FakeCube:
+    def __init__(self, data, mask=None):
+        self.data = data
+        self.mask = mask
+
+    def to_nddata(self, **kwargs):
+        return types.SimpleNamespace(data=kwargs["data"], mask=self.mask)
 
 
 @pytest.fixture
@@ -205,6 +215,61 @@ def test_remove_cosmic_rays_astroscrappy_inmask_combined(sns_sjicube_1330, mock_
     assert len(calls) == 2
     np.testing.assert_array_equal(calls[0], mask[0] | inmask[0])
     np.testing.assert_array_equal(calls[1], mask[1] | inmask[1])
+
+
+def test_remove_cosmic_rays_astroscrappy_broadcasts_2d_inmask(sns_sjicube_1330, mock_cosmic_ray_backend):
+    calls = []
+
+    def fake_detect_cosmics(frame, *, inmask=None, **kwargs):  # NOQA: ARG001
+        calls.append(inmask.copy())
+        return np.zeros_like(frame, dtype=bool), frame.copy()
+
+    fake_module = types.SimpleNamespace(detect_cosmics=fake_detect_cosmics)
+    mock_cosmic_ray_backend(fake_module)
+
+    cube = sns_sjicube_1330[:2, :3, :4]
+    cube.data[...] = np.ones((2, 3, 4), dtype=float)
+    cube.mask = np.zeros(cube.data.shape, dtype=bool)
+    inmask = np.zeros((3, 4), dtype=bool)
+    inmask[0, 0] = True
+
+    remove_cosmic_rays(cube, method="astroscrappy", method_kwargs={"inmask": inmask})
+
+    assert len(calls) == 2
+    np.testing.assert_array_equal(calls[0], inmask)
+    np.testing.assert_array_equal(calls[1], inmask)
+
+
+def test_remove_cosmic_rays_astroscrappy_handles_dask_frames(mock_cosmic_ray_backend):
+    calls = []
+
+    def fake_detect_cosmics(frame, *, inmask=None, **kwargs):  # NOQA: ARG001
+        calls.append((frame.copy(), inmask.copy()))
+        return frame > 10, frame - 1
+
+    fake_module = types.SimpleNamespace(detect_cosmics=fake_detect_cosmics)
+    mock_cosmic_ray_backend(fake_module)
+
+    data = np.arange(24, dtype=float).reshape(2, 3, 4)
+    data[1, 2, 3] = np.nan
+    mask = np.zeros(data.shape, dtype=bool)
+    mask[0, 0, 0] = True
+    cube = FakeCube(da.from_array(data, chunks=(1, 3, 4)), da.from_array(mask, chunks=(1, 3, 4)))
+
+    cleaned_cube = remove_cosmic_rays(cube, method="astroscrappy")
+
+    assert len(calls) == 2
+    assert calls[0][1][0, 0]
+    assert calls[1][1][2, 3]
+    assert calls[1][0][2, 3] == pytest.approx(0.0)
+    assert cleaned_cube.data[1, 2, 3] == pytest.approx(-1.0)
+
+
+def test_remove_cosmic_rays_rsliding_rejects_dask_cube():
+    cube = FakeCube(da.from_array(np.ones((2, 3, 4)), chunks=(1, 3, 4)))
+
+    with pytest.raises(ValueError, match="requires the full cube in memory"):
+        remove_cosmic_rays(cube, method="rsliding")
 
 
 @pytest.mark.parametrize("method", ["rsliding", "astroscrappy"])

--- a/irispy/visualization.py
+++ b/irispy/visualization.py
@@ -11,6 +11,7 @@ __all__ = ["IRISArrayAnimatorWCS", "IRISPlotter", "IRISSequencePlotter"]
 
 LAT_LABELS = [
     "custom:pos.helioprojective.lat",
+    "helioprojective latitude",
     "hplt-tan",
     "hplt",
     "lat",
@@ -18,12 +19,26 @@ LAT_LABELS = [
 ]
 LON_LABELS = [
     "custom:pos.helioprojective.lon",
+    "helioprojective longitude",
     "hpln-tan",
     "hpln",
     "lon",
     "longitude",
 ]
+TIME_LABELS = ["time (utc)", "time"]
 WAVELENGTH_LABELS = ["wavelength", "wave", "em.wl"]
+SCAN_LABELS = set(LON_LABELS + LAT_LABELS)
+
+
+def _shorten_slider_label(label):
+    label_parts = {label_part.strip().lower() for label_part in str(label).split(" / ")}
+    if label_parts.intersection(WAVELENGTH_LABELS):
+        return "Wavelength"
+    if label_parts.intersection(TIME_LABELS):
+        return "Time"
+    if label_parts and label_parts.issubset(SCAN_LABELS):
+        return "Scan"
+    return label
 
 
 def set_axis_properties(ax):
@@ -67,12 +82,13 @@ class Plot2DMixin:
 
 
 class IRISArrayAnimatorWCS(Plot2DMixin, ArrayAnimatorWCS):
-    pass
+    def _compute_slider_labels_from_wcs(self, slices):
+        return [_shorten_slider_label(label) for label in super()._compute_slider_labels_from_wcs(slices)]
 
 
 class IRISSequenceAnimator(Plot2DMixin, SequenceAnimator):
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("slider_labels", ["Raster Step", "Scan Number"])
+        kwargs.setdefault("slider_labels", ["Raster step", "Scan number"])
         super().__init__(*args, **kwargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "astropy>=7.2.0",
+  "dask[array]>=2024.6.0",
   "dkist>=1.17.0",
+  "gwcs>=1.0.0",
   "mpl-animators>=1.2.0",
   "ndcube>=2.4.0",
   "pandas>=3.0.0",
@@ -58,7 +60,6 @@ optional-dependencies.dev = [
 optional-dependencies.docs = [
   "irispy-lmsal[all]",
   "aiapy>=0.9.0",
-  "dask[distributed]>=2024.6.0",
   "pooch>=1.9.0",
   "sphinx-automodapi>=0.18.0",
   "sphinx-changelog>=1.6.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -47,3 +47,4 @@ filterwarnings =
     # Fix these one day.
     ignore::erfa.core.ErfaWarning
     ignore:target cannot be converted to ICRS, so will not be set on SpectralCoord
+    ignore:invalid value encountered in do_format:RuntimeWarning


### PR DESCRIPTION
## Summary by Sourcery

Improve cosmic ray removal, WCS generation, and visualization slider labeling while adding dask support and updating dependencies.

New Features:
- Support Dask-backed data and masks in astroscrappy-based cosmic ray removal.
- Automatically shorten WCS-derived slider labels for IRIS visualizations based on axis semantics.

Bug Fixes:
- Handle NaN values and in-mask combination correctly per-frame in astroscrappy cosmic ray detection.
- Ensure velocity-space WCS construction is robust by building it directly from array shape and velocity grid instead of modifying an existing WCS header.
- Reject use of the rsliding cosmic-ray removal method on Dask-backed cubes that cannot be fully loaded into memory.

Enhancements:
- Relax type annotations in rsliding cosmic ray removal helpers to work with non-NumPy array backends.
- Standardize default raster sequence slider labels to sentence case for consistency.

Build:
- Add runtime dependencies on dask[array] and gwcs and remove the docs-only dependency on dask[distributed].

Tests:
- Add tests covering Dask-backed astroscrappy cosmic ray removal and validation of rsliding behavior with Dask cubes.
- Add visualization tests to assert shortened default slider labels and respect for custom slider labels.